### PR TITLE
tokenize interpreted string text

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -471,7 +471,7 @@ module.exports = grammar({
 
     _interpreted_string_literal: $ => seq(
       '"',
-      repeat(choice(token.immediate(/[^"\\\n\r]/), $.escape_sequence)),
+      repeat(choice(token.immediate(/[^"\\\n\r]+/), $.escape_sequence)),
       '"'
     ),
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3325,7 +3325,7 @@
                 "type": "IMMEDIATE_TOKEN",
                 "content": {
                   "type": "PATTERN",
-                  "value": "[^\"\\\\\\n\\r]"
+                  "value": "[^\"\\\\\\n\\r]+"
                 }
               },
               {


### PR DESCRIPTION
This prevents multiple syntax node being created for each characters but
instead try to group them whenever possible.