### PR TITLE
reduce the number of externals in the grammar and expand strings nodes

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -26,6 +26,7 @@ Diagnostics:
     - readability-*
     Remove: modernize-use-trailing-return-type
     CheckOptions: 
+      cppcoreguidelines-avoid-do-while.IgnoreMacros: true
       readability-function-cognitive-complexity.IgnoreMacros: true
       readability-implicit-bool-conversion.AllowPointerConditions: true
       readability-identifier-naming.ClassCase: CamelCase

--- a/corpus/deviations.txt
+++ b/corpus/deviations.txt
@@ -1,0 +1,44 @@
+================================================================================
+Literal deviations
+================================================================================
+
+"string
+#[comment]#"
+
+'a
+#[]#'
+
+r"string
+#[comment]#"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (string_literal
+    (block_comment))
+  (char_literal
+    (block_comment))
+  (string_literal
+    (block_comment)))
+
+================================================================================
+Generalized string deviations
+================================================================================
+
+a#[]#"b"
+
+a.b #[]#"c"
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (generalized_string
+    (identifier)
+    (block_comment)
+    (string_literal))
+  (generalized_string
+    (dot_expression
+      (identifier)
+      (identifier))
+    (block_comment)
+    (string_literal)))

--- a/corpus/deviations.txt
+++ b/corpus/deviations.txt
@@ -42,3 +42,19 @@ a.b #[]#"c"
       (identifier))
     (block_comment)
     (string_literal)))
+
+================================================================================
+Except deviations
+================================================================================
+
+import x
+except y
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (import_statement
+    (identifier)
+    (except_clause
+      (expression_list
+        (identifier)))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -261,7 +261,6 @@ $a.b
 
 a.b"string"
 a.b "string"
-a.b#[]#"string"
 
 a(
   b
@@ -298,12 +297,6 @@ a(
     function: (dot_expression
       left: (identifier)
       right: (identifier))
-    (string_literal))
-  (call
-    function: (dot_expression
-      left: (identifier)
-      right: (identifier))
-    (comment)
     (string_literal))
   (dot_expression
     left: (call

--- a/corpus/extras.txt
+++ b/corpus/extras.txt
@@ -52,9 +52,9 @@ echo x,
     (identifier)
     (comment)
     (identifier))
-  (comment)
-  (comment)
-  (comment))
+  (documentation_comment)
+  (documentation_comment)
+  (documentation_comment))
 
 ================================================================================
 Block comments
@@ -68,13 +68,18 @@ comments can be #[nested
 
 #[random inner comments# stuff#]#
 
+##[Block doc can be #[nested]# too
+Block doc is not ##[self-nesting]#, though
+]##
+
 --------------------------------------------------------------------------------
 
 (source_file
   (call
     (identifier)
     (identifier)
-    (comment)
+    (block_comment)
     (identifier))
-  (comment)
-  (comment))
+  (block_comment)
+  (block_comment)
+  (block_documentation_comment))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -168,9 +168,13 @@ r"C:\"
     (escape_sequence))
   (string_literal)
   (string_literal)
-  (string_literal)
-  (string_literal)
-  (string_literal)
+  (string_literal
+    (escape_sequence)
+    (escape_sequence))
+  (string_literal
+    (escape_sequence))
+  (string_literal
+    (escape_sequence))
   (string_literal)
   (string_literal)
   (string_literal)
@@ -207,12 +211,18 @@ Character literals
   (char_literal)
   (char_literal)
   (char_literal)
-  (char_literal)
-  (char_literal)
-  (char_literal)
-  (char_literal)
-  (char_literal)
-  (char_literal))
+  (char_literal
+    (escape_sequence))
+  (char_literal
+    (escape_sequence))
+  (char_literal
+    (escape_sequence))
+  (char_literal
+    (escape_sequence))
+  (char_literal
+    (escape_sequence))
+  (char_literal
+    (escape_sequence)))
 
 ================================================================================
 Nil literal

--- a/grammar.js
+++ b/grammar.js
@@ -221,12 +221,7 @@ module.exports = grammar({
     $._invalid_layout,
     $._sigil_operator,
     $.prefix_operator,
-    keyword_regex("elif"),
-    keyword_regex("else"),
-    keyword_regex("except"),
-    keyword_regex("finally"),
     $._case_of,
-    keyword_regex("do"),
   ],
 
   conflicts: $ => [[$._command_function, $._simple_expression_command_start]],
@@ -509,7 +504,7 @@ module.exports = grammar({
       ),
     _elif_declaration_branch: $ =>
       seq(
-        keyword_alias("elif"),
+        keyword("elif"),
         field("condition", $._expression),
         ":",
         field(
@@ -540,7 +535,7 @@ module.exports = grammar({
       ),
     _else_declaration_branch: $ =>
       seq(
-        keyword_alias("else"),
+        keyword("else"),
         ":",
         alias($._object_field_declaration_branch_list, $.field_declaration_list)
       ),
@@ -686,23 +681,23 @@ module.exports = grammar({
       ),
     elif_branch: $ =>
       seq(
-        keyword_alias("elif"),
+        keyword("elif"),
         field("condition", $._expression),
         ":",
         field("consequence", $.statement_list)
       ),
-    else_branch: $ => seq(keyword_alias("else"), ":", $.statement_list),
+    else_branch: $ => seq(keyword("else"), ":", $.statement_list),
     except_branch: $ =>
       seq(
-        keyword_alias("except"),
+        keyword("except"),
         optional(field("values", $.expression_list)),
         ":",
         $.statement_list
       ),
-    finally_branch: $ => seq(keyword_alias("finally"), ":", $.statement_list),
+    finally_branch: $ => seq(keyword("finally"), ":", $.statement_list),
     do_block: $ =>
       seq(
-        keyword_alias("do"),
+        keyword("do"),
         optional($.parameter_declaration_list),
         optional(seq("->", $._type_expression)),
         ":",
@@ -1247,15 +1242,6 @@ function keyword_regex(ident) {
     .join("_?");
 
   return new RegExp(regex);
-}
-
-/**
- * keyword_regex() but with aliasing to make it pretty
- *
- * @param {string} ident
- */
-function keyword_alias(ident) {
-  return alias(keyword_regex(ident), ident);
 }
 
 /**

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2028,8 +2028,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "e_?[lL]_?[iI]_?[fF]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "e_?[lL]_?[iI]_?[fF]"
+              }
+            }
           },
           "named": false,
           "value": "elif"
@@ -2185,8 +2192,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "e_?[lL]_?[sS]_?[eE]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "e_?[lL]_?[sS]_?[eE]"
+              }
+            }
           },
           "named": false,
           "value": "else"
@@ -3181,8 +3195,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "e_?[lL]_?[iI]_?[fF]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "e_?[lL]_?[iI]_?[fF]"
+              }
+            }
           },
           "named": false,
           "value": "elif"
@@ -3215,8 +3236,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "e_?[lL]_?[sS]_?[eE]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "e_?[lL]_?[sS]_?[eE]"
+              }
+            }
           },
           "named": false,
           "value": "else"
@@ -3237,8 +3265,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "e_?[xX]_?[cC]_?[eE]_?[pP]_?[tT]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "e_?[xX]_?[cC]_?[eE]_?[pP]_?[tT]"
+              }
+            }
           },
           "named": false,
           "value": "except"
@@ -3275,8 +3310,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "f_?[iI]_?[nN]_?[aA]_?[lL]_?[lL]_?[yY]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "f_?[iI]_?[nN]_?[aA]_?[lL]_?[lL]_?[yY]"
+              }
+            }
           },
           "named": false,
           "value": "finally"
@@ -3297,8 +3339,15 @@
         {
           "type": "ALIAS",
           "content": {
-            "type": "PATTERN",
-            "value": "d_?[oO]"
+            "type": "TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 1,
+              "content": {
+                "type": "PATTERN",
+                "value": "d_?[oO]"
+              }
+            }
           },
           "named": false,
           "value": "do"
@@ -10258,28 +10307,8 @@
       "name": "prefix_operator"
     },
     {
-      "type": "PATTERN",
-      "value": "e_?[lL]_?[iI]_?[fF]"
-    },
-    {
-      "type": "PATTERN",
-      "value": "e_?[lL]_?[sS]_?[eE]"
-    },
-    {
-      "type": "PATTERN",
-      "value": "e_?[xX]_?[cC]_?[eE]_?[pP]_?[tT]"
-    },
-    {
-      "type": "PATTERN",
-      "value": "f_?[iI]_?[nN]_?[aA]_?[lL]_?[lL]_?[yY]"
-    },
-    {
       "type": "SYMBOL",
       "name": "_case_of"
-    },
-    {
-      "type": "PATTERN",
-      "value": "d_?[oO]"
     }
   ],
   "inline": [],

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -3507,13 +3507,11 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "ALIAS",
+                "type": "IMMEDIATE_TOKEN",
                 "content": {
-                  "type": "SYMBOL",
-                  "name": "_immediate_paren_open"
-                },
-                "named": false,
-                "value": "("
+                  "type": "STRING",
+                  "value": "("
+                }
               },
               {
                 "type": "CHOICE",
@@ -3911,13 +3909,11 @@
               "value": "["
             },
             {
-              "type": "ALIAS",
+              "type": "IMMEDIATE_TOKEN",
               "content": {
-                "type": "SYMBOL",
-                "name": "_immediate_bracket_open"
-              },
-              "named": false,
-              "value": "["
+                "type": "STRING",
+                "value": "["
+              }
             }
           ]
         },
@@ -8167,13 +8163,11 @@
             }
           },
           {
-            "type": "ALIAS",
+            "type": "IMMEDIATE_TOKEN",
             "content": {
-              "type": "SYMBOL",
-              "name": "_immediate_bracket_open"
-            },
-            "named": false,
-            "value": "["
+              "type": "STRING",
+              "value": "["
+            }
           },
           {
             "type": "FIELD",
@@ -8218,13 +8212,11 @@
             }
           },
           {
-            "type": "ALIAS",
+            "type": "IMMEDIATE_TOKEN",
             "content": {
-              "type": "SYMBOL",
-              "name": "_immediate_curly_open"
-            },
-            "named": false,
-            "value": "{"
+              "type": "STRING",
+              "value": "{"
+            }
           },
           {
             "type": "FIELD",
@@ -8411,13 +8403,11 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
+              "type": "IMMEDIATE_TOKEN",
               "content": {
-                "type": "SYMBOL",
-                "name": "_immediate_long_string_start"
-              },
-              "named": false,
-              "value": "\"\"\""
+                "type": "STRING",
+                "value": "\"\"\""
+              }
             },
             {
               "type": "SYMBOL",
@@ -8429,13 +8419,11 @@
           "type": "SEQ",
           "members": [
             {
-              "type": "ALIAS",
+              "type": "IMMEDIATE_TOKEN",
               "content": {
-                "type": "SYMBOL",
-                "name": "_immediate_string_start"
-              },
-              "named": false,
-              "value": "\""
+                "type": "STRING",
+                "value": "\""
+              }
             },
             {
               "type": "SYMBOL",
@@ -8727,13 +8715,11 @@
               "value": "("
             },
             {
-              "type": "ALIAS",
+              "type": "IMMEDIATE_TOKEN",
               "content": {
-                "type": "SYMBOL",
-                "name": "_immediate_paren_open"
-              },
-              "named": false,
-              "value": "("
+                "type": "STRING",
+                "value": "("
+              }
             }
           ]
         },
@@ -9550,39 +9536,58 @@
       }
     },
     "char_literal": {
-      "type": "TOKEN",
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "'"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "PREC",
+                "value": 2,
+                "content": {
+                  "type": "PATTERN",
+                  "value": "[^\\\\\\n\\r']"
+                }
+              }
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_char_escape_sequence"
+              },
+              "named": true,
+              "value": "escape_sequence"
+            }
+          ]
+        },
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "'"
+          }
+        }
+      ]
+    },
+    "_char_escape_sequence": {
+      "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "SEQ",
         "members": [
           {
             "type": "STRING",
-            "value": "'"
+            "value": "\\"
           },
           {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "PATTERN",
-                "value": "[^\\\\']"
-              },
-              {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "\\"
-                  },
-                  {
-                    "type": "PATTERN",
-                    "value": "[rRcCnNlLfFtTvV\\\\\"'aAbBeE]|\\d+|x[0-9a-fA-F]{2}"
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            "type": "STRING",
-            "value": "'"
+            "type": "PATTERN",
+            "value": "[rRcCnNlLfFtTvV\\\\\"'aAbBeE]|\\d+|[xX][0-9a-fA-F]{2}"
           }
         ]
       }
@@ -9617,8 +9622,15 @@
             "type": "CHOICE",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "_string_content"
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 2,
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\n\\r\"\\\\]+"
+                  }
+                }
               },
               {
                 "type": "SYMBOL",
@@ -9637,7 +9649,7 @@
       ]
     },
     "escape_sequence": {
-      "type": "TOKEN",
+      "type": "IMMEDIATE_TOKEN",
       "content": {
         "type": "SEQ",
         "members": [
@@ -9650,7 +9662,7 @@
             "members": [
               {
                 "type": "PATTERN",
-                "value": "[rRcCnNlLfFtTvV\\\\\"'aAbBeE]|\\d+|x[0-9a-fA-F]{2}"
+                "value": "[rRcCnNlLfFtTvV\\\\\"'aAbBeE]|\\d+|[xX][0-9a-fA-F]{2}"
               },
               {
                 "type": "PATTERN",
@@ -9684,8 +9696,29 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "_raw_string_content"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 2,
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\n\\r\"]"
+                  }
+                }
+              },
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_raw_string_escape"
+                },
+                "named": true,
+                "value": "escape_sequence"
+              }
+            ]
           }
         },
         {
@@ -9696,6 +9729,13 @@
           }
         }
       ]
+    },
+    "_raw_string_escape": {
+      "type": "IMMEDIATE_TOKEN",
+      "content": {
+        "type": "STRING",
+        "value": "\"\""
+      }
     },
     "_long_string_literal": {
       "type": "SEQ",
@@ -9716,8 +9756,24 @@
         {
           "type": "REPEAT",
           "content": {
-            "type": "SYMBOL",
-            "name": "_long_string_content"
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 2,
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\"]+"
+                  }
+                }
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_long_string_quote"
+              }
+            ]
           }
         },
         {
@@ -9786,6 +9842,62 @@
           }
         ]
       }
+    },
+    "block_documentation_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "STRING",
+              "value": "##["
+            }
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_block_documentation_comment_content"
+        },
+        {
+          "type": "STRING",
+          "value": "]##"
+        }
+      ]
+    },
+    "block_comment": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "TOKEN",
+          "content": {
+            "type": "PREC",
+            "value": 1,
+            "content": {
+              "type": "STRING",
+              "value": "#["
+            }
+          }
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_block_comment_content"
+        },
+        {
+          "type": "STRING",
+          "value": "]#"
+        }
+      ]
+    },
+    "documentation_comment": {
+      "type": "PATTERN",
+      "value": "##[^\\n\\r]*"
+    },
+    "comment": {
+      "type": "PATTERN",
+      "value": "#[^\\n\\r]*"
     }
   },
   "extras": [
@@ -9795,7 +9907,23 @@
     },
     {
       "type": "SYMBOL",
+      "name": "_synchronize"
+    },
+    {
+      "type": "SYMBOL",
       "name": "comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "documentation_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "block_documentation_comment"
     }
   ],
   "conflicts": [
@@ -10067,39 +10195,15 @@
   "externals": [
     {
       "type": "SYMBOL",
-      "name": "comment"
+      "name": "_block_comment_content"
     },
     {
       "type": "SYMBOL",
-      "name": "_immediate_paren_open"
+      "name": "_block_documentation_comment_content"
     },
     {
       "type": "SYMBOL",
-      "name": "_immediate_bracket_open"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_immediate_curly_open"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_immediate_string_start"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_immediate_long_string_start"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_string_content"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_raw_string_content"
-    },
-    {
-      "type": "SYMBOL",
-      "name": "_long_string_content"
+      "name": "_long_string_quote"
     },
     {
       "type": "SYMBOL",
@@ -10138,8 +10242,8 @@
       "name": "unused_curly_dot"
     },
     {
-      "type": "PATTERN",
-      "value": "[\\n\\r ]+"
+      "type": "SYMBOL",
+      "name": "_synchronize"
     },
     {
       "type": "SYMBOL",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -762,6 +762,16 @@
     }
   },
   {
+    "type": "block_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "block_documentation_comment",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "bracket_expression",
     "named": true,
     "fields": {
@@ -1942,6 +1952,21 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "char_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "escape_sequence",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -13452,6 +13477,18 @@
     "named": false
   },
   {
+    "type": "##[",
+    "named": false
+  },
+  {
+    "type": "#[",
+    "named": false
+  },
+  {
+    "type": "'",
+    "named": false
+  },
+  {
     "type": "(",
     "named": false
   },
@@ -13500,6 +13537,14 @@
     "named": false
   },
   {
+    "type": "]#",
+    "named": false
+  },
+  {
+    "type": "]##",
+    "named": false
+  },
+  {
     "type": "`",
     "named": false
   },
@@ -13534,10 +13579,6 @@
   {
     "type": "cast",
     "named": false
-  },
-  {
-    "type": "char_literal",
-    "named": true
   },
   {
     "type": "comment",
@@ -13578,6 +13619,10 @@
   {
     "type": "do",
     "named": false
+  },
+  {
+    "type": "documentation_comment",
+    "named": true
   },
   {
     "type": "elif",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -32,15 +32,9 @@ constexpr auto BitsInByte = 8;
 
 enum class TokenType : TSSymbol {
   TokenTypeStart,
-  Comment = TokenTypeStart,
-  ImmediateParenOpen,
-  ImmediateBracketOpen,
-  ImmediateCurlyOpen,
-  ImmediateStringStart,
-  ImmediateLongStringStart,
-  StringContent,
-  RawStringContent,
-  LongStringContent,
+  BlockCommentContent = TokenTypeStart,
+  BlockDocCommentContent,
+  LongStringQuote,
   LayoutStart,
   LayoutEnd,
   LayoutTerminator,
@@ -50,7 +44,7 @@ enum class TokenType : TSSymbol {
   BracketClose,
   CurlyClose,
   CurlyDotClose,
-  Spaces,
+  Synchronize,
   InvalidLayout,
   SigilOp,
   UnaryOp,
@@ -74,7 +68,7 @@ constexpr ValidSymbols make_valid_symbols(initializer_list<TokenType> syms)
   return result;
 }
 
-enum class Flag { AfterNewline, NoImmediates, FlagLen };
+enum class Flag { AfterNewline, FlagLen };
 
 struct State {
   vector<uint8_t> layout_stack;
@@ -582,28 +576,11 @@ bool lex(Context& ctx, bool immediate)
 }  // namespace operators
 
 namespace comment {
-enum class Marker { Invalid, LineComment, BlockComment, BlockDocComment };
+enum class Marker { Invalid, BlockComment, BlockDocComment };
+constexpr auto CommentContent = make_valid_symbols(
+    {TokenType::BlockCommentContent, TokenType::BlockDocCommentContent});
 
-Marker start_marker(Context& ctx)
-{
-  switch (ctx.lookahead()) {
-  case '#':
-    switch (ctx.consume()) {
-    case '#':
-      if (ctx.consume() == '[') {
-        return Marker::BlockDocComment;
-      }
-      return Marker::LineComment;
-    case '[':
-      return Marker::BlockComment;
-    }
-    return Marker::LineComment;
-  default:
-    return Marker::Invalid;
-  }
-}
-
-bool consume_end_marker(Context& ctx, Marker type)
+bool lex_end_marker(Context& ctx, Marker type)
 {
   switch (type) {
   case Marker::BlockComment:
@@ -611,76 +588,47 @@ bool consume_end_marker(Context& ctx, Marker type)
     if (ctx.lookahead() != ']') {
       return false;
     }
-    if (ctx.consume() != '#') {
+    if (ctx.advance() != '#') {
       return false;
     }
     if (type == Marker::BlockComment) {
-      ctx.consume();
+      ctx.advance();
       return true;
     }
-    if (ctx.consume() != '#') {
+    if (ctx.advance() != '#') {
       return false;
     }
-    ctx.consume();
+    ctx.advance();
     return true;
   default:
     return false;
   }
 }
 
-bool handle_line_comment(Context& ctx)
-{
-  while (!ctx.eof()) {
-    switch (ctx.lookahead()) {
-    case '\n':
-    case '\r':
-      return ctx.finish(TokenType::Comment);
-    }
-    ctx.consume();
-  }
-  return ctx.finish(TokenType::Comment);
-}
-
 bool lex(Context& ctx)
 {
-  if (!ctx.valid(TokenType::Comment)) {
+  if (!ctx.any_valid(CommentContent) || ctx.error()) {
     return false;
   }
 
-  bool long_doc = false;
-  switch (start_marker(ctx)) {
-  case Marker::LineComment:
-    return handle_line_comment(ctx);
-  case Marker::BlockDocComment:
-    long_doc = true;
-    [[fallthrough]];
-  case Marker::BlockComment:
-    break;
-  default:
-    return false;
-  }
+  bool long_doc = ctx.valid(TokenType::BlockDocCommentContent);
 
   uint32_t nesting = 0;
   while (!ctx.eof()) {
-    const auto last_state = ctx.counter();
+    const auto want_end = nesting > 0 || !long_doc ? Marker::BlockComment
+                                                   : Marker::BlockDocComment;
 
-    switch (start_marker(ctx)) {
-    case Marker::BlockComment:
-    case Marker::BlockDocComment:
+    if (ctx.lookahead() == '#' && ctx.advance() == '[') {
       nesting++;
 #ifdef TREE_SITTER_INTERNAL_BUILD
       if (getenv("TREE_SITTER_DEBUG")) {
         cerr << "lex_nim: block comment nest level: " << nesting << '\n';
       }
 #endif
-      break;
-    default:
-      break;
     }
-    const auto want_end = nesting > 0 || !long_doc ? Marker::BlockComment
-                                                   : Marker::BlockDocComment;
 
-    if (consume_end_marker(ctx, want_end)) {
+    ctx.mark_end();
+    if (lex_end_marker(ctx, want_end)) {
 #ifdef TREE_SITTER_INTERNAL_BUILD
       if (getenv("TREE_SITTER_DEBUG")) {
         cerr << "lex_nim: block comment terminate nest level: " << nesting
@@ -688,14 +636,14 @@ bool lex(Context& ctx)
       }
 #endif
       if (nesting == 0) {
-        ctx.state().set_flag(Flag::NoImmediates);
-        return ctx.finish(TokenType::Comment);
+        return ctx.finish(
+            long_doc ? TokenType::BlockDocCommentContent
+                     : TokenType::BlockCommentContent);
       }
       nesting--;
     }
-
-    if (last_state == ctx.counter()) {
-      ctx.consume();
+    else {
+      ctx.advance();
     }
   }
 
@@ -703,116 +651,30 @@ bool lex(Context& ctx)
 }
 }  // namespace comment
 
-namespace string_lex {
-constexpr auto StringTokens = make_valid_symbols(
-    {TokenType::StringContent, TokenType::RawStringContent,
-     TokenType::LongStringContent});
-constexpr auto StringStartTokens = make_valid_symbols(
-    {TokenType::ImmediateStringStart, TokenType::ImmediateLongStringStart});
-constexpr auto RawStringType = make_valid_symbols(
-    {TokenType::LongStringContent, TokenType::RawStringContent});
-
-bool handle_string_quote(Context& ctx)
+bool lex_long_string_quote(Context& ctx)
 {
-  if (ctx.lookahead() != '"' || !ctx.any_valid(RawStringType)) {
+  if (ctx.lookahead() != '"' || !ctx.valid(TokenType::LongStringQuote)) {
     return false;
   }
 
   ctx.consume();
-  if (ctx.valid(TokenType::RawStringContent)) {
-    if (ctx.lookahead() == '"') {
-      ctx.consume();
-      return ctx.finish(TokenType::RawStringContent);
-    }
-
-    return false;
+  uint8_t count = 1;
+  while (ctx.lookahead() == '"' && count < 3) {
+    ctx.advance();
+    count++;
   }
 
-  if (ctx.valid(TokenType::LongStringContent)) {
-    uint8_t count = 1;
-    while (ctx.lookahead() == '"' && count < 3) {
-      ctx.advance();
-      count++;
-    }
+  if (count < 3) {
+    ctx.mark_end();
+    return ctx.finish(TokenType::LongStringQuote);
+  }
 
-    if (count < 3 || ctx.lookahead() == '"') {
-      return ctx.finish(TokenType::LongStringContent);
-    }
-    return false;
+  if (ctx.lookahead() == '"') {
+    return ctx.finish(TokenType::LongStringQuote);
   }
 
   return false;
 }
-
-bool lex_string_start(Context& ctx)
-{
-  if (!ctx.any_valid(StringStartTokens) ||
-      ctx.state().test_flag(Flag::NoImmediates) || ctx.lookahead() != '"') {
-    return false;
-  }
-
-  ctx.consume();
-  if (ctx.valid(TokenType::ImmediateLongStringStart)) {
-    uint8_t count = 1;
-    while (ctx.lookahead() == '"' && count < 3) {
-      ctx.advance();
-      count++;
-    }
-    if (count == 3) {
-      ctx.mark_end();
-      return ctx.finish(TokenType::ImmediateLongStringStart);
-    }
-  }
-
-  return ctx.finish(TokenType::ImmediateStringStart);
-}
-
-bool lex(Context& ctx)
-{
-  if (!ctx.any_valid(StringTokens) || ctx.error()) {
-    return false;
-  }
-
-  TRY_LEX(ctx, handle_string_quote);
-  bool has_content = false;
-  // NOLINTBEGIN(*-avoid-goto)
-  while (!ctx.eof()) {
-    switch (ctx.lookahead()) {
-    case '\n':
-    case '\r':
-      if (!ctx.valid(TokenType::LongStringContent)) {
-        goto loop_break;
-      }
-      [[fallthrough]];
-    case '\\':
-      if (!ctx.any_valid(RawStringType)) {
-        goto loop_break;
-      }
-      break;
-    case '"':
-      goto loop_break;
-    }
-
-    has_content = true;
-    ctx.consume();
-  }
-  // NOLINTEND(*-avoid-goto)
-
-loop_break:
-  return has_content && ctx.finish(
-                            ctx.valid(TokenType::LongStringContent)
-                                ? TokenType::LongStringContent
-                            : ctx.valid(TokenType::RawStringContent)
-                                ? TokenType::RawStringContent
-                                : TokenType::StringContent);
-}
-}  // namespace string_lex
-
-constexpr auto ImmediateTokens = make_valid_symbols(
-    {TokenType::ImmediateParenOpen, TokenType::ImmediateBracketOpen,
-     TokenType::ImmediateCurlyOpen, TokenType::ImmediateStringStart,
-     TokenType::ImmediateLongStringStart, TokenType::StringContent,
-     TokenType::LongStringContent, TokenType::RawStringContent});
 
 void skip_underscore(Context& ctx)
 {
@@ -984,7 +846,9 @@ bool lex_indent(Context& ctx)
     }
   }
 
-  if (current_layout > line_indent && !ctx.eof()) {
+  if (current_layout > line_indent && !ctx.eof() &&
+      // In long string context
+      !ctx.valid(TokenType::LongStringQuote)) {
     ctx.mark_end();
     return ctx.finish(TokenType::InvalidLayout);
   }
@@ -1035,67 +899,33 @@ loop_end:
 
 bool lex_init(Context& ctx)
 {
-  if (!ctx.state().layout_stack.empty()) {
+  if (!ctx.state().layout_stack.empty() || ctx.error()) {
     return false;
   }
 
   scan_spaces(ctx, true);
-  TRY_LEX(ctx, comment::lex);
-
-  ctx.mark_end();
-  ctx.state().layout_stack.push_back(ctx.state().line_indent);
-  return ctx.finish(TokenType::Spaces);
-}
-
-bool lex_immediates(Context& ctx)
-{
-  if (!ctx.any_valid(ImmediateTokens) ||
-      ctx.state().test_flag(Flag::NoImmediates)) {
+  if (ctx.lookahead() == '#') {
     return false;
   }
 
-  TRY_LEX(ctx, string_lex::lex_string_start);
-
-  if (ctx.lookahead() == '(' && ctx.valid(TokenType::ImmediateParenOpen)) {
-    ctx.consume();
-    return ctx.finish(TokenType::ImmediateParenOpen);
-  }
-  if (ctx.lookahead() == '[' && ctx.valid(TokenType::ImmediateBracketOpen)) {
-    ctx.consume();
-    return ctx.finish(TokenType::ImmediateBracketOpen);
-  }
-  if (ctx.lookahead() == '{' && ctx.valid(TokenType::ImmediateCurlyOpen)) {
-    ctx.consume();
-    if (ctx.lookahead() == '.') {
-      return false;
-    }
-    return ctx.finish(TokenType::ImmediateCurlyOpen);
-  }
-  return false;
+  ctx.mark_end();
+  ctx.state().layout_stack.push_back(ctx.state().line_indent);
+  return ctx.finish(TokenType::Synchronize);
 }
 
 bool lex_main(Context& ctx)
 {
   TRY_LEX(ctx, lex_init);
 
-  TRY_LEX(ctx, lex_immediates);
-  TRY_LEX(ctx, string_lex::lex);
+  TRY_LEX(ctx, comment::lex);
+  TRY_LEX(ctx, lex_long_string_quote);
 
   auto spaces = scan_spaces(ctx);
-  ctx.mark_end();
 
-  TRY_LEX(ctx, comment::lex);
   TRY_LEX(ctx, lex_indent);
-  TRY_LEXN(
-      ctx, operators::lex,
-      spaces == 0 && !ctx.state().test_flag(Flag::NoImmediates));
+  TRY_LEXN(ctx, operators::lex, spaces == 0);
   TRY_LEX(ctx, lex_keyword);
   TRY_LEX(ctx, lex_inline_layout);
-
-  if (spaces > 0 && !ctx.state().test_flag(Flag::NoImmediates)) {
-    ctx.state().set_flag(Flag::NoImmediates);
-    return ctx.finish(TokenType::Spaces);
-  }
 
   return false;
 }
@@ -1141,12 +971,12 @@ bool tree_sitter_nim_external_scanner_scan(
 #endif
 
   const auto last_count = ctx.counter();
+  const auto last_flags = ctx.state().flags;
   if (lex_main(ctx)) {
     return true;
   }
 
   if (!ctx.eof() && ctx.counter() == last_count) {
-    bool commit = false;
     if (ctx.state().test_flag(Flag::AfterNewline)) {
 #ifdef TREE_SITTER_INTERNAL_BUILD
       if (getenv("TREE_SITTER_DEBUG")) {
@@ -1154,20 +984,9 @@ bool tree_sitter_nim_external_scanner_scan(
       }
 #endif
       ctx.state().reset_flag(Flag::AfterNewline);
-      commit = true;
     }
-    if (ctx.state().test_flag(Flag::NoImmediates) &&
-        !ctx.any_valid(ImmediateTokens)) {
-#ifdef TREE_SITTER_INTERNAL_BUILD
-      if (getenv("TREE_SITTER_DEBUG")) {
-        cerr << "lex_nim: resetting no immediate flag\n";
-      }
-#endif
-      ctx.state().reset_flag(Flag::NoImmediates);
-      commit = true;
-    }
-    if (commit) {
-      return ctx.finish(TokenType::Spaces);
+    if (last_flags != ctx.state().flags) {
+      return ctx.finish(TokenType::Synchronize);
     }
   }
 


### PR DESCRIPTION
A lot of tokens were externalized to deal with conflicts between them and other external tokens.

This presented an issue: tree-sitter could not merge parse states automatically since it has to be mindful of these external tokens.

This PR attempts to pull back on the number of externals used to the bare minimum and accept inaccuracies where applicable (ie. no one would write code like this).

Most of the magic is done by making extras purely internal lexer first. This gives the external lexer complete confidence of where the extras are invoked without fighting with the internal lexer.

Doing this also allowed us to expand `escape_sequence` to more nodes, facilitating better syntax highlighting.

The next big thing is the unconditional treatment of `elif`/`else`/`except`/`finally` as line continuations. This allowed those tokens to be withdrawn from externals and enabled even more state compression. Alone this change halved the size of the generated parser to 59MiB.