### PR TITLE
fix inline conditional declaration

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -343,6 +343,8 @@ type
 type
   C = object
   D = ref object
+  E = object
+    when foo: x: int
 
 --------------------------------------------------------------------------------
 
@@ -538,7 +540,20 @@ type
         name: (identifier))
       (modified_type
         modifier: (ref_type)
-        (object_declaration)))))
+        (object_declaration)))
+    (type_declaration
+      (type_symbol_declaration
+        name: (identifier))
+      (object_declaration
+        (field_declaration_list
+          (conditional_declaration
+            condition: (identifier)
+            consequence: (field_declaration_list
+              (field_declaration
+                (symbol_declaration_list
+                  (symbol_declaration
+                    name: (identifier)))
+                type: (identifier)))))))))
 
 ================================================================================
 Tuple declarations

--- a/grammar.js
+++ b/grammar.js
@@ -490,7 +490,13 @@ module.exports = grammar({
           keyword("when"),
           field("condition", $._expression),
           ":",
-          field("consequence", $._object_field_declaration_list),
+          field(
+            "consequence",
+            alias(
+              $._object_field_declaration_branch_list,
+              $.field_declaration_list
+            )
+          ),
           repeat(
             field(
               "alternative",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1985,8 +1985,13 @@
             "type": "FIELD",
             "name": "consequence",
             "content": {
-              "type": "SYMBOL",
-              "name": "_object_field_declaration_list"
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_object_field_declaration_branch_list"
+              },
+              "named": true,
+              "value": "field_declaration_list"
             }
           },
           {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2504,27 +2504,11 @@
         ]
       },
       "consequence": {
-        "multiple": true,
+        "multiple": false,
         "required": true,
         "types": [
           {
-            "type": "conditional_declaration",
-            "named": true
-          },
-          {
-            "type": "discard_statement",
-            "named": true
-          },
-          {
-            "type": "field_declaration",
-            "named": true
-          },
-          {
-            "type": "nil_literal",
-            "named": true
-          },
-          {
-            "type": "variant_declaration",
+            "type": "field_declaration_list",
             "named": true
           }
         ]


### PR DESCRIPTION
Fix erroneous use of `_object_field_declaration_list` in
`conditional_declaration`. It should've been the branch
variant to allow for inline declaration.
