### PR TITLE
rework calls to no longer require conflicts

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -651,7 +651,8 @@ type
             function: (dot_expression
               left: (identifier)
               right: (identifier))
-            (identifier)))))
+            (argument_list
+              (identifier))))))
     (type_declaration
       (type_symbol_declaration
         name: (exported_symbol
@@ -730,21 +731,24 @@ type
               function: (dot_expression
                 left: (identifier)
                 right: (identifier))
-              (identifier))
+              (argument_list
+                (identifier)))
             right: (identifier))
           (infix_expression
             left: (call
               function: (dot_expression
                 left: (identifier)
                 right: (identifier))
-              (identifier))
+              (argument_list
+                (identifier)))
             right: (identifier))
           (infix_expression
             left: (call
               function: (dot_expression
                 left: (identifier)
                 right: (identifier))
-              (identifier))
+              (argument_list
+                (identifier)))
             right: (bracket_expression
               left: (identifier)
               right: (argument_list
@@ -794,8 +798,9 @@ proc bar
       (call
         function: (accent_quoted
           (identifier))
-        (identifier)
-        (integer_literal)))
+        (argument_list
+          (identifier)
+          (integer_literal))))
     parameters: (parameter_declaration_list
       (parameter_declaration
         (symbol_declaration_list
@@ -831,7 +836,8 @@ proc bar
     body: (statement_list
       (call
         function: (identifier)
-        (string_literal))))
+        (argument_list
+          (string_literal)))))
   (iterator_declaration
     name: (identifier)
     parameters: (parameter_declaration_list
@@ -869,7 +875,8 @@ proc bar
     body: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (proc_declaration
     name: (identifier)))
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -94,9 +94,10 @@ echo $a
       (identifier)))
   (call
     function: (identifier)
-    (prefix_expression
-      operator: (prefix_operator)
-      (identifier))))
+    (argument_list
+      (prefix_expression
+        operator: (prefix_operator)
+        (identifier)))))
 
 ================================================================================
 Infix expressions
@@ -227,10 +228,11 @@ else: 4
     operator: (infix_operator)
     right: (call
       function: (identifier)
-      (infix_expression
-        left: (integer_literal)
-        operator: (infix_operator)
-        right: (identifier))))
+      (argument_list
+        (infix_expression
+          left: (integer_literal)
+          operator: (infix_operator)
+          right: (identifier)))))
   (infix_expression
     left: (integer_literal)
     operator: (infix_operator)
@@ -297,11 +299,13 @@ a(
     function: (dot_expression
       left: (identifier)
       right: (identifier))
-    (string_literal))
+    (argument_list
+      (string_literal)))
   (dot_expression
     left: (call
       function: (identifier)
-      (identifier))
+      (argument_list
+        (identifier)))
     right: (identifier)))
 
 ================================================================================
@@ -417,120 +421,139 @@ collect(for x in s:
 (source_file
   (call
     function: (identifier)
-    (identifier))
+    (argument_list
+      (identifier)))
   (call
     function: (identifier)
-    (integer_literal)
-    (identifier)
-    (float_literal))
+    (argument_list
+      (integer_literal)
+      (identifier)
+      (float_literal)))
   (call
     function: (identifier)
-    (string_literal)
-    (string_literal))
-  (call
-    function: (identifier)
-    (string_literal))
-  (call
-    function: (identifier)
-    (call
-      function: (identifier)
-      (string_literal))
-    (string_literal)
-    (call
-      function: (identifier)
+    (argument_list
+      (string_literal)
       (string_literal)))
   (call
-    function: (identifier))
+    function: (identifier)
+    (argument_list
+      (string_literal)))
   (call
     function: (identifier)
-    (statement_list
+    (argument_list
       (call
-        function: (identifier))
+        function: (identifier)
+        (argument_list
+          (string_literal)))
+      (string_literal)
       (call
-        function: (identifier))))
+        function: (identifier)
+        (argument_list
+          (string_literal)))))
   (call
     function: (identifier)
-    (statement_list
-      (infix_expression
-        left: (integer_literal)
-        operator: (infix_operator)
-        right: (integer_literal))
-      (identifier))
-    (else_branch
-      (statement_list
-        (identifier))))
+    (argument_list))
   (call
     function: (identifier)
-    (statement_list)
-    (of_branch
-      values: (expression_list
-        (integer_literal)
-        (integer_literal))
+    (argument_list
       (statement_list
         (call
           function: (identifier)
-          (identifier)
-          (statement_list
-            (identifier))
-          (else_branch
-            (statement_list
-              (identifier)))))))
+          (argument_list))
+        (call
+          function: (identifier)
+          (argument_list)))))
   (call
     function: (identifier)
-    (do_block
-      (parameter_declaration_list
-        (parameter_declaration
-          (symbol_declaration_list
-            (symbol_declaration
-              name: (identifier))
-            (symbol_declaration
-              name: (identifier)))
-          type: (identifier)))
-      (identifier)
-      body: (statement_list
+    (argument_list
+      (statement_list
         (infix_expression
-          left: (identifier)
+          left: (integer_literal)
           operator: (infix_operator)
-          right: (identifier)))))
+          right: (integer_literal))
+        (identifier))
+      (else_branch
+        (statement_list
+          (identifier)))))
   (call
     function: (identifier)
-    (do_block
-      body: (statement_list
-        (identifier)))
-    (do_block
-      body: (statement_list
-        (identifier))))
+    (argument_list
+      (statement_list)
+      (of_branch
+        values: (expression_list
+          (integer_literal)
+          (integer_literal))
+        (statement_list
+          (call
+            function: (identifier)
+            (argument_list
+              (identifier)
+              (statement_list
+                (identifier))
+              (else_branch
+                (statement_list
+                  (identifier)))))))))
   (call
     function: (identifier)
-    (statement_list
-      (identifier))
-    (do_block
-      body: (statement_list
-        (identifier))))
-  (call
-    function: (identifier)
-    (equal_expression
-      left: (identifier)
-      right: (identifier))
-    (equal_expression
-      left: (identifier)
-      right: (if
-        condition: (identifier)
-        consequence: (statement_list
-          (identifier))))
-    (identifier))
-  (call
-    function: (identifier)
-    (for
-      left: (symbol_declaration_list
-        (symbol_declaration
-          name: (identifier)))
-      right: (identifier)
-      body: (statement_list
-        (curly_construction
-          (colon_expression
+    (argument_list
+      (do_block
+        (parameter_declaration_list
+          (parameter_declaration
+            (symbol_declaration_list
+              (symbol_declaration
+                name: (identifier))
+              (symbol_declaration
+                name: (identifier)))
+            type: (identifier)))
+        return_type: (identifier)
+        body: (statement_list
+          (infix_expression
             left: (identifier)
-            right: (identifier)))))))
+            operator: (infix_operator)
+            right: (identifier))))))
+  (call
+    function: (identifier)
+    (argument_list
+      (do_block
+        body: (statement_list
+          (identifier)))
+      (do_block
+        body: (statement_list
+          (identifier)))))
+  (call
+    function: (identifier)
+    (argument_list
+      (statement_list
+        (identifier))
+      (do_block
+        body: (statement_list
+          (identifier)))))
+  (call
+    function: (identifier)
+    (argument_list
+      (equal_expression
+        left: (identifier)
+        right: (identifier))
+      (equal_expression
+        left: (identifier)
+        right: (if
+          condition: (identifier)
+          consequence: (statement_list
+            (identifier))))
+      (identifier)))
+  (call
+    function: (identifier)
+    (argument_list
+      (for
+        left: (symbol_declaration_list
+          (symbol_declaration
+            name: (identifier)))
+        right: (identifier)
+        body: (statement_list
+          (curly_construction
+            (colon_expression
+              left: (identifier)
+              right: (identifier))))))))
 
 ================================================================================
 Command calls
@@ -577,108 +600,133 @@ foo {x}
 (source_file
   (call
     function: (identifier)
-    (call
-      function: (identifier)
-      (integer_literal))
-    (string_literal)
-    (call
-      function: (identifier)
-      (integer_literal)))
-  (call
-    function: (identifier)
-    (identifier)
-    (identifier)
-    (string_literal)
-    (call
-      function: (identifier)
+    (argument_list
       (call
         function: (identifier)
+        (argument_list
+          (integer_literal)))
+      (string_literal)
+      (call
+        function: (identifier)
+        (argument_list
+          (integer_literal)))))
+  (call
+    function: (identifier)
+    (argument_list
+      (identifier)
+      (identifier)
+      (string_literal)
+      (call
+        function: (identifier)
+        (argument_list
+          (call
+            function: (identifier)
+            (argument_list
+              (call
+                function: (identifier)
+                (argument_list
+                  (identifier)))))))))
+  (call
+    function: (identifier)
+    (argument_list
+      (call
+        function: (identifier)
+        (argument_list
+          (call
+            function: (identifier)
+            (argument_list
+              (identifier)))))))
+  (call
+    function: (identifier)
+    (argument_list
+      (statement_list
         (call
           function: (identifier)
+          (argument_list
+            (identifier)
+            (identifier)
+            (statement_list
+              (call
+                function: (identifier)
+                (argument_list
+                  (identifier))))
+            (of_branch
+              values: (expression_list
+                (identifier)
+                (identifier))
+              (statement_list
+                (identifier))))))))
+  (call
+    function: (identifier)
+    (argument_list
+      (string_literal)))
+  (call
+    function: (identifier)
+    (argument_list
+      (string_literal)))
+  (call
+    function: (identifier)
+    (argument_list
+      (identifier)
+      (identifier)
+      (identifier)
+      (statement_list
+        (identifier))
+      (do_block
+        body: (statement_list
           (identifier)))))
   (call
     function: (identifier)
-    (call
-      function: (identifier)
-      (call
-        function: (identifier)
-        (identifier))))
-  (call
-    function: (identifier)
-    (statement_list
-      (call
-        function: (identifier)
-        (identifier)
-        (identifier)
-        (statement_list
-          (call
-            function: (identifier)
-            (identifier)))
-        (of_branch
-          values: (expression_list
-            (identifier)
-            (identifier))
-          (statement_list
-            (identifier))))))
-  (call
-    function: (identifier)
-    (string_literal))
-  (call
-    function: (identifier)
-    (string_literal))
-  (call
-    function: (identifier)
-    (identifier)
-    (identifier)
-    (identifier)
-    (statement_list
-      (identifier))
-    (do_block
-      body: (statement_list
-        (identifier))))
-  (call
-    function: (identifier)
-    (identifier)
-    (statement_list
-      (identifier)))
-  (call
-    function: (identifier)
-    (identifier)
-    (statement_list
-      (identifier))
-    (else_branch
+    (argument_list
+      (identifier)
       (statement_list
         (identifier))))
   (call
     function: (identifier)
-    (call
-      function: (identifier)
-      (do_block
-        body: (statement_list
-          (identifier)))
+    (argument_list
+      (identifier)
+      (statement_list
+        (identifier))
       (else_branch
         (statement_list
           (identifier)))))
   (call
     function: (identifier)
-    (infix_expression
-      left: (integer_literal)
-      operator: (infix_operator)
-      right: (call
-        function: (identifier)))
-    (identifier))
+    (argument_list
+      (call
+        function: (identifier)
+        (argument_list
+          (do_block
+            body: (statement_list
+              (identifier)))
+          (else_branch
+            (statement_list
+              (identifier)))))))
   (call
     function: (identifier)
-    (tuple_construction
+    (argument_list
+      (infix_expression
+        left: (integer_literal)
+        operator: (infix_operator)
+        right: (call
+          function: (identifier)
+          (argument_list)))
       (identifier)))
   (call
     function: (identifier)
-    (array_construction
-      (identifier)))
+    (argument_list
+      (tuple_construction
+        (identifier))))
   (call
     function: (identifier)
-    (curly_construction
-      (identifier))))
+    (argument_list
+      (array_construction
+        (identifier))))
+  (call
+    function: (identifier)
+    (argument_list
+      (curly_construction
+        (identifier)))))
 
 ================================================================================
 Block statements
@@ -707,10 +755,12 @@ let y = block:
     body: (statement_list
       (call
         function: (identifier)
-        (identifier))
+        (argument_list
+          (identifier)))
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (block
     body: (statement_list
       (let_section
@@ -721,7 +771,8 @@ let y = block:
           value: (integer_literal)))
       (call
         function: (identifier)
-        (integer_literal))))
+        (argument_list
+          (integer_literal)))))
   (let_section
     (variable_declaration
       (symbol_declaration_list
@@ -775,13 +826,15 @@ else: expr2
     consequence: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (if
     condition: (identifier)
     consequence: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (if
     condition: (identifier)
     consequence: (statement_list
@@ -795,7 +848,8 @@ else: expr2
             (integer_literal))))
       (call
         function: (identifier)
-        (identifier)))
+        (argument_list
+          (identifier))))
     alternative: (else_branch
       (statement_list
         (integer_literal))))
@@ -882,13 +936,15 @@ else: expr2
     consequence: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (when
     condition: (identifier)
     consequence: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (when
     condition: (identifier)
     consequence: (statement_list
@@ -904,7 +960,8 @@ else: expr2
               consequence: (statement_list
                 (call
                   function: (identifier)
-                  (identifier))))
+                  (argument_list
+                    (identifier)))))
             (integer_literal)))))
     alternative: (else_branch
       (statement_list
@@ -999,10 +1056,12 @@ let x = case something(10)
       (statement_list
         (call
           function: (identifier)
-          (identifier))
+          (argument_list
+            (identifier)))
         (call
           function: (identifier)
-          (identifier))
+          (argument_list
+            (identifier)))
         (integer_literal)))
     (of_branch
       values: (expression_list
@@ -1021,16 +1080,19 @@ let x = case something(10)
       consequence: (statement_list
         (call
           function: (identifier)
-          (integer_literal))))
+          (argument_list
+            (integer_literal)))))
     (else_branch
       (statement_list
         (call
           function: (identifier)
-          (string_literal)))))
+          (argument_list
+            (string_literal))))))
   (case
     value: (call
       function: (identifier)
-      (integer_literal))
+      (argument_list
+        (integer_literal)))
     (of_branch
       values: (expression_list
         (identifier))
@@ -1060,7 +1122,8 @@ let x = case something(10)
       value: (case
         value: (call
           function: (identifier)
-          (integer_literal))
+          (argument_list
+            (integer_literal)))
         (of_branch
           values: (expression_list
             (identifier))
@@ -1104,32 +1167,38 @@ except: echo y
     body: (statement_list
       (call
         function: (identifier)
-        (string_literal))
+        (argument_list
+          (string_literal)))
       (call
         function: (identifier)
-        (string_literal)))
+        (argument_list
+          (string_literal))))
     (except_branch
       values: (expression_list
         (identifier))
       (statement_list
         (call
           function: (identifier)
-          (identifier)))))
+          (argument_list
+            (identifier))))))
   (try
     body: (statement_list
       (call
         function: (identifier)
-        (string_literal))
+        (argument_list
+          (string_literal)))
       (call
         function: (identifier)
-        (string_literal)))
+        (argument_list
+          (string_literal))))
     (except_branch
       values: (expression_list
         (identifier))
       (statement_list
         (call
           function: (identifier)
-          (identifier))))
+          (argument_list
+            (identifier)))))
     (except_branch
       values: (expression_list
         (identifier)
@@ -1137,22 +1206,26 @@ except: echo y
       (statement_list
         (call
           function: (identifier)
-          (identifier))))
+          (argument_list
+            (identifier)))))
     (finally_branch
       (statement_list
         (call
           function: (identifier)
-          (identifier)))))
+          (argument_list
+            (identifier))))))
   (try
     body: (statement_list
       (call
         function: (identifier)
-        (identifier)))
+        (argument_list
+          (identifier))))
     (except_branch
       (statement_list
         (call
           function: (identifier)
-          (identifier))))))
+          (argument_list
+            (identifier)))))))
 
 ================================================================================
 Pragma statements
@@ -1174,11 +1247,13 @@ Pragma statements
       (colon_expression
         left: (identifier)
         right: (call
-          function: (identifier))))
+          function: (identifier)
+          (argument_list))))
     body: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (pragma_statement
     (pragma_list
       (identifier))

--- a/corpus/extras.txt
+++ b/corpus/extras.txt
@@ -49,9 +49,10 @@ echo x,
       (float_literal)))
   (call
     (identifier)
-    (identifier)
-    (comment)
-    (identifier))
+    (argument_list
+      (identifier)
+      (comment)
+      (identifier)))
   (documentation_comment)
   (documentation_comment)
   (documentation_comment))
@@ -77,9 +78,10 @@ Block doc is not ##[self-nesting]#, though
 (source_file
   (call
     (identifier)
-    (identifier)
-    (block_comment)
-    (identifier))
+    (argument_list
+      (identifier)
+      (block_comment)
+      (identifier)))
   (block_comment)
   (block_comment)
   (block_documentation_comment))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -33,7 +33,8 @@ for _, v {.tag.} in c.pairs:
         name: (identifier)))
     right: (call
       function: (identifier)
-      (identifier))
+      (argument_list
+        (identifier)))
     body: (statement_list
       (integer_literal)))
   (for
@@ -220,8 +221,9 @@ discard foo as bar
   (discard_statement
     (call
       function: (identifier)
-      (statement_list
-        (identifier))))
+      (argument_list
+        (statement_list
+          (identifier)))))
   (discard_statement
     (infix_expression
       left: (identifier)
@@ -393,14 +395,18 @@ static:
     body: (statement_list
       (call
         function: (identifier)
-        (identifier))))
+        (argument_list
+          (identifier)))))
   (static_statement
     body: (statement_list
       (call
-        function: (identifier))
-      (call
-        function: (identifier))
+        function: (identifier)
+        (argument_list))
       (call
         function: (identifier)
-        (identifier)
-        (string_literal)))))
+        (argument_list))
+      (call
+        function: (identifier)
+        (argument_list
+          (identifier)
+          (string_literal))))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -221,15 +221,6 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "_command_statement"
-          },
-          "named": true,
-          "value": "call"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
             "name": "_call_extended"
           },
           "named": true,
@@ -1546,15 +1537,6 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
-            "name": "_command_statement"
-          },
-          "named": true,
-          "value": "call"
-        },
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
             "name": "_call_extended"
           },
           "named": true,
@@ -1679,38 +1661,42 @@
       ]
     },
     "enum_field_declaration": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "SYMBOL",
-          "name": "symbol_declaration"
-        },
-        {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "="
-                },
-                {
-                  "type": "FIELD",
-                  "name": "value",
-                  "content": {
-                    "type": "SYMBOL",
-                    "name": "_simple_expression"
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "symbol_declaration"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "FIELD",
+                    "name": "value",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_simple_expression"
+                    }
                   }
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        }
-      ]
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
     },
     "_tuple_declaration": {
       "type": "SEQ",
@@ -2566,6 +2552,15 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
+            "name": "_command_block"
+          },
+          "named": true,
+          "value": "call"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
             "name": "_infix_extended"
           },
           "named": true,
@@ -3370,25 +3365,29 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": "->"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "_type_expression"
-                }
-              ]
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
+          "type": "FIELD",
+          "name": "return_type",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "->"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_type_expression"
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
         },
         {
           "type": "STRING",
@@ -3405,101 +3404,209 @@
       ]
     },
     "_call_extended": {
-      "type": "PREC",
-      "value": "post_expr",
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_command_statement"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_call_block"
+        }
+      ]
+    },
+    "_command_statement": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_basic_expression"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_statement_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
+    "_command_statement_argument_list": {
+      "type": "PREC_RIGHT",
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_equal_expression_list"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ":"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "statement_list"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "SYMBOL",
+                        "name": "_post_expression_block_tail"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_command_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_basic_expression"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_block_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
+    "_command_block_argument_list": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_command_expression_argument_list"
+          },
+          {
+            "type": "STRING",
+            "value": ":"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "statement_list"
+          },
           {
             "type": "CHOICE",
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_call_expression"
+                "name": "_post_expression_block_tail"
               },
               {
-                "type": "SYMBOL",
-                "name": "_command_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_command_statement"
-              },
-              {
-                "type": "FIELD",
-                "name": "function",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_command_function"
-                }
+                "type": "BLANK"
               }
             ]
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_post_expression_block"
-          }
-        ]
-      }
-    },
-    "_command_statement": {
-      "type": "PREC_DYNAMIC",
-      "value": -2,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "function",
-            "content": {
-              "type": "SYMBOL",
-              "name": "_command_function"
-            }
-          },
-          {
-            "type": "SYMBOL",
-            "name": "_equal_expression_list"
           }
         ]
       }
     },
     "_call_block": {
-      "type": "PREC_RIGHT",
-      "value": "post_expr",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_call_expression"
-              },
-              {
-                "type": "SYMBOL",
-                "name": "_command_expression"
-              },
-              {
-                "type": "FIELD",
-                "name": "function",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_command_function"
-                }
-              }
-            ]
-          },
-          {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "function",
+          "content": {
             "type": "SYMBOL",
-            "name": "_post_expression_block"
+            "name": "_basic_expression"
           }
-        ]
-      }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_call_block_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
+    "_call_block_argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_call_argument_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_post_expression_block"
+        }
+      ]
     },
     "_call_do": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_basic_expression"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_call_do_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
+    "_call_do_argument_list": {
       "type": "PREC_RIGHT",
-      "value": "post_expr",
+      "value": 0,
       "content": {
         "type": "SEQ",
         "members": [
@@ -3508,19 +3615,10 @@
             "members": [
               {
                 "type": "SYMBOL",
-                "name": "_call_expression"
+                "name": "_call_argument_list"
               },
               {
-                "type": "SYMBOL",
-                "name": "_command_expression"
-              },
-              {
-                "type": "FIELD",
-                "name": "function",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_command_function"
-                }
+                "type": "BLANK"
               }
             ]
           },
@@ -3558,65 +3656,75 @@
             }
           },
           {
-            "type": "SEQ",
-            "members": [
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "STRING",
-                  "value": "("
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SYMBOL",
-                    "name": "_colon_equal_expression_list"
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "STRING",
-                "value": ")"
-              }
-            ]
-          }
-        ]
-      }
-    },
-    "_command_expression": {
-      "type": "PREC_DYNAMIC",
-      "value": -1,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "function",
+            "type": "ALIAS",
             "content": {
               "type": "SYMBOL",
-              "name": "_command_function"
-            }
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_simple_expression_command_start"
-              }
-            ]
+              "name": "_call_argument_list"
+            },
+            "named": true,
+            "value": "argument_list"
           }
         ]
       }
     },
-    "_command_function": {
-      "type": "SYMBOL",
-      "name": "_basic_expression"
+    "_call_argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "("
+          }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_colon_equal_expression_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_command_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_basic_expression"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_expression_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
+    "_command_expression_argument_list": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_simple_expression_command_start"
+        }
+      ]
     },
     "_post_expression_block": {
       "type": "PREC_RIGHT",
@@ -9980,12 +10088,7 @@
       "name": "block_documentation_comment"
     }
   ],
-  "conflicts": [
-    [
-      "_command_function",
-      "_simple_expression_command_start"
-    ]
-  ],
+  "conflicts": [],
   "precedences": [
     [
       {
@@ -10128,16 +10231,6 @@
     [
       {
         "type": "SYMBOL",
-        "name": "_post_expression_block"
-      },
-      {
-        "type": "SYMBOL",
-        "name": "_call_do"
-      }
-    ],
-    [
-      {
-        "type": "SYMBOL",
         "name": "var_section"
       },
       {
@@ -10188,16 +10281,6 @@
     [
       {
         "type": "SYMBOL",
-        "name": "_sigil_expression"
-      },
-      {
-        "type": "SYMBOL",
-        "name": "_command_function"
-      }
-    ],
-    [
-      {
-        "type": "SYMBOL",
         "name": "_simple_expression"
       },
       {
@@ -10243,6 +10326,96 @@
       {
         "type": "SYMBOL",
         "name": "_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_simple_expression"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_command_expression_argument_list"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_simple_expression_command_start"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_command_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_call_do_argument_list"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_call_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_call_do"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_simple_expression_command_start"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_call_do_argument_list"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_post_expression_block"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_call_block_argument_list"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_call_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_call_block"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_simple_expression_command_start"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_command_block_argument_list"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_command_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_simple_expression_command_start"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_command_statement"
       }
     ]
   ],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -20,7 +20,7 @@
     "fields": {},
     "children": {
       "multiple": true,
-      "required": true,
+      "required": false,
       "types": [
         {
           "type": "accent_quoted",
@@ -75,7 +75,19 @@
           "named": true
         },
         {
+          "type": "do_block",
+          "named": true
+        },
+        {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "elif_branch",
+          "named": true
+        },
+        {
+          "type": "else_branch",
           "named": true
         },
         {
@@ -84,6 +96,14 @@
         },
         {
           "type": "equal_expression",
+          "named": true
+        },
+        {
+          "type": "except_branch",
+          "named": true
+        },
+        {
+          "type": "finally_branch",
           "named": true
         },
         {
@@ -139,6 +159,10 @@
           "named": true
         },
         {
+          "type": "of_branch",
+          "named": true
+        },
+        {
           "type": "out_type",
           "named": true
         },
@@ -168,6 +192,10 @@
         },
         {
           "type": "ref_type",
+          "named": true
+        },
+        {
+          "type": "statement_list",
           "named": true
         },
         {
@@ -1228,207 +1256,11 @@
       }
     },
     "children": {
-      "multiple": true,
-      "required": false,
+      "multiple": false,
+      "required": true,
       "types": [
         {
-          "type": "accent_quoted",
-          "named": true
-        },
-        {
-          "type": "array_construction",
-          "named": true
-        },
-        {
-          "type": "block",
-          "named": true
-        },
-        {
-          "type": "bracket_expression",
-          "named": true
-        },
-        {
-          "type": "call",
-          "named": true
-        },
-        {
-          "type": "case",
-          "named": true
-        },
-        {
-          "type": "cast",
-          "named": true
-        },
-        {
-          "type": "char_literal",
-          "named": true
-        },
-        {
-          "type": "colon_expression",
-          "named": true
-        },
-        {
-          "type": "curly_construction",
-          "named": true
-        },
-        {
-          "type": "curly_expression",
-          "named": true
-        },
-        {
-          "type": "custom_numeric_literal",
-          "named": true
-        },
-        {
-          "type": "distinct_type",
-          "named": true
-        },
-        {
-          "type": "do_block",
-          "named": true
-        },
-        {
-          "type": "dot_expression",
-          "named": true
-        },
-        {
-          "type": "elif_branch",
-          "named": true
-        },
-        {
-          "type": "else_branch",
-          "named": true
-        },
-        {
-          "type": "enum_type",
-          "named": true
-        },
-        {
-          "type": "equal_expression",
-          "named": true
-        },
-        {
-          "type": "except_branch",
-          "named": true
-        },
-        {
-          "type": "finally_branch",
-          "named": true
-        },
-        {
-          "type": "float_literal",
-          "named": true
-        },
-        {
-          "type": "for",
-          "named": true
-        },
-        {
-          "type": "func_expression",
-          "named": true
-        },
-        {
-          "type": "generalized_string",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "if",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "iterator_expression",
-          "named": true
-        },
-        {
-          "type": "iterator_type",
-          "named": true
-        },
-        {
-          "type": "modified_type",
-          "named": true
-        },
-        {
-          "type": "nil_literal",
-          "named": true
-        },
-        {
-          "type": "object_type",
-          "named": true
-        },
-        {
-          "type": "of_branch",
-          "named": true
-        },
-        {
-          "type": "out_type",
-          "named": true
-        },
-        {
-          "type": "parenthesized",
-          "named": true
-        },
-        {
-          "type": "pointer_type",
-          "named": true
-        },
-        {
-          "type": "pragma_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "proc_expression",
-          "named": true
-        },
-        {
-          "type": "proc_type",
-          "named": true
-        },
-        {
-          "type": "ref_type",
-          "named": true
-        },
-        {
-          "type": "statement_list",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "try",
-          "named": true
-        },
-        {
-          "type": "tuple_construction",
-          "named": true
-        },
-        {
-          "type": "tuple_type",
-          "named": true
-        },
-        {
-          "type": "var_type",
-          "named": true
-        },
-        {
-          "type": "when",
+          "type": "argument_list",
           "named": true
         }
       ]
@@ -3443,142 +3275,152 @@
             "named": true
           }
         ]
+      },
+      "return_type": {
+        "multiple": true,
+        "required": false,
+        "types": [
+          {
+            "type": "->",
+            "named": false
+          },
+          {
+            "type": "accent_quoted",
+            "named": true
+          },
+          {
+            "type": "array_construction",
+            "named": true
+          },
+          {
+            "type": "bracket_expression",
+            "named": true
+          },
+          {
+            "type": "call",
+            "named": true
+          },
+          {
+            "type": "cast",
+            "named": true
+          },
+          {
+            "type": "char_literal",
+            "named": true
+          },
+          {
+            "type": "curly_construction",
+            "named": true
+          },
+          {
+            "type": "curly_expression",
+            "named": true
+          },
+          {
+            "type": "custom_numeric_literal",
+            "named": true
+          },
+          {
+            "type": "distinct_type",
+            "named": true
+          },
+          {
+            "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "enum_type",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "generalized_string",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "infix_expression",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "modified_type",
+            "named": true
+          },
+          {
+            "type": "nil_literal",
+            "named": true
+          },
+          {
+            "type": "object_type",
+            "named": true
+          },
+          {
+            "type": "out_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized",
+            "named": true
+          },
+          {
+            "type": "pointer_type",
+            "named": true
+          },
+          {
+            "type": "pragma_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "proc_type",
+            "named": true
+          },
+          {
+            "type": "ref_type",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "tuple_construction",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "var_type",
+            "named": true
+          }
+        ]
       }
     },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": false,
       "types": [
         {
-          "type": "accent_quoted",
-          "named": true
-        },
-        {
-          "type": "array_construction",
-          "named": true
-        },
-        {
-          "type": "bracket_expression",
-          "named": true
-        },
-        {
-          "type": "call",
-          "named": true
-        },
-        {
-          "type": "cast",
-          "named": true
-        },
-        {
-          "type": "char_literal",
-          "named": true
-        },
-        {
-          "type": "curly_construction",
-          "named": true
-        },
-        {
-          "type": "curly_expression",
-          "named": true
-        },
-        {
-          "type": "custom_numeric_literal",
-          "named": true
-        },
-        {
-          "type": "distinct_type",
-          "named": true
-        },
-        {
-          "type": "dot_expression",
-          "named": true
-        },
-        {
-          "type": "enum_type",
-          "named": true
-        },
-        {
-          "type": "float_literal",
-          "named": true
-        },
-        {
-          "type": "generalized_string",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "infix_expression",
-          "named": true
-        },
-        {
-          "type": "integer_literal",
-          "named": true
-        },
-        {
-          "type": "iterator_type",
-          "named": true
-        },
-        {
-          "type": "modified_type",
-          "named": true
-        },
-        {
-          "type": "nil_literal",
-          "named": true
-        },
-        {
-          "type": "object_type",
-          "named": true
-        },
-        {
-          "type": "out_type",
-          "named": true
-        },
-        {
           "type": "parameter_declaration_list",
-          "named": true
-        },
-        {
-          "type": "parenthesized",
-          "named": true
-        },
-        {
-          "type": "pointer_type",
-          "named": true
-        },
-        {
-          "type": "pragma_expression",
-          "named": true
-        },
-        {
-          "type": "prefix_expression",
-          "named": true
-        },
-        {
-          "type": "proc_type",
-          "named": true
-        },
-        {
-          "type": "ref_type",
-          "named": true
-        },
-        {
-          "type": "string_literal",
-          "named": true
-        },
-        {
-          "type": "tuple_construction",
-          "named": true
-        },
-        {
-          "type": "tuple_type",
-          "named": true
-        },
-        {
-          "type": "var_type",
           "named": true
         }
       ]


### PR DESCRIPTION
Previously, the GLR parser was required to resolve conflicts between
command and expressions. This however causes extremely high parser error
recovery time.

This commit rewrite the related rules to no longer require conflicts.
The node structure has also been updated to expose argument_list,
allowing easier matches for captures.

As an added bonus, the parser size shrunk again, from 59MiB to 42MiB.
