### PR TITLE
enable inline block termination for other structures

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1239,6 +1239,9 @@ Pragma statements
 
 {.cast(noSideEffect).}
 
+{.line: when X:
+  instantiationInfo().}
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1265,7 +1268,17 @@ Pragma statements
   (pragma_statement
     (pragma_list
       (cast
-        value: (identifier)))))
+        value: (identifier))))
+  (pragma_statement
+    (pragma_list
+      (colon_expression
+        left: (identifier)
+        right: (when
+          condition: (identifier)
+          consequence: (statement_list
+            (call
+              function: (identifier)
+              (argument_list))))))))
 
 ================================================================================
 Type expressions
@@ -1373,6 +1386,9 @@ y, z, 10,
 []
 [[a]]
 
+[c: if c:
+  d]
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1396,7 +1412,14 @@ y, z, 10,
   (array_construction)
   (array_construction
     (array_construction
-      (identifier))))
+      (identifier)))
+  (array_construction
+    (colon_expression
+      (identifier)
+      (if
+        (identifier)
+        (statement_list
+          (identifier))))))
 
 ================================================================================
 Set/Table construction
@@ -1408,6 +1431,9 @@ Set/Table construction
 
 {}
 {:}
+
+{a: when c:
+  d}
 
 --------------------------------------------------------------------------------
 
@@ -1425,7 +1451,14 @@ Set/Table construction
     (identifier)
     (identifier))
   (curly_construction)
-  (curly_construction))
+  (curly_construction)
+  (curly_construction
+    (colon_expression
+      (identifier)
+      (when
+        (identifier)
+        (statement_list
+          (identifier))))))
 
 ================================================================================
 Tuple construction

--- a/grammar.js
+++ b/grammar.js
@@ -214,9 +214,12 @@ module.exports = grammar({
     ",",
     // @ts-ignore: DSL not updated for literals
     ")",
-    $.unused_bracket, // "]",
-    $.unused_curly, // "}",
-    $.unused_curly_dot, // ".}",
+    // @ts-ignore: DSL not updated for literals
+    "]",
+    // @ts-ignore: DSL not updated for literals
+    "}",
+    // @ts-ignore: DSL not updated for literals
+    ".}",
     $._synchronize,
     $._invalid_layout,
     $._sigil_operator,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10457,16 +10457,16 @@
       "value": ")"
     },
     {
-      "type": "SYMBOL",
-      "name": "unused_bracket"
+      "type": "STRING",
+      "value": "]"
     },
     {
-      "type": "SYMBOL",
-      "name": "unused_curly"
+      "type": "STRING",
+      "value": "}"
     },
     {
-      "type": "SYMBOL",
-      "name": "unused_curly_dot"
+      "type": "STRING",
+      "value": ".}"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -350,7 +350,6 @@ bool lex_inline_layout(Context& ctx, bool read_dot = false)
       return false;
     }
     break;
-#if 0  // Keep off until grammar can support it
   case ']':
     if (ctx.valid(TokenType::BracketClose)) {
       return false;
@@ -365,10 +364,14 @@ bool lex_inline_layout(Context& ctx, bool read_dot = false)
   case '.':
     if (!read_dot) {
       ctx.advance();
-      return lex_inline_layout(ctx, true);
+      if (ctx.lookahead() == '}') {
+        if (ctx.valid(TokenType::CurlyDotClose)) {
+          return false;
+        }
+        break;
+      }
     }
     return false;
-#endif
   default:
     return false;
   }


### PR DESCRIPTION
Now that the parser size has gone down, support for inline block termination of `]`, `}` and `.}` can now be enabled.