### PR TITLE
supports more structures and many bug fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,25 @@ jobs:
   #         fi
   #       shell: bash
 
+  generate:
+    name: Generate parser
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          cache: "npm"
+          node-version: "16"
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-artifact@v3
+        with:
+          name: parser
+          path: src/parser.c
+
   tests:
+    needs:
+      - generate
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -40,7 +58,10 @@ jobs:
           node-version: "16"
           cache: "npm"
       - run: npm install
-      - run: npm run build
+      - uses: actions/download-artifact@v3
+        with:
+          name: parser
+          path: src
       - name: Run test suite
         run: |
           if [[ "$RUNNER_OS" == macOS ]]; then
@@ -56,6 +77,8 @@ jobs:
         shell: bash
 
   rust:
+    needs:
+      - generate
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -63,12 +86,10 @@ jobs:
     name: Run rust test build on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/download-artifact@v3
         with:
-          node-version: "16"
-          cache: "npm"
-      - run: npm install
-      - run: npm run build
+          name: parser
+          path: src
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -778,6 +778,12 @@ converter toInt(x: Natural): int =
 
 proc bar
 
+proc bar =
+  ## comment
+
+proc foo =
+  ## comment
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -878,7 +884,15 @@ proc bar
         (argument_list
           (identifier)))))
   (proc_declaration
-    name: (identifier)))
+    name: (identifier))
+  (proc_declaration
+    name: (identifier)
+    (documentation_comment)
+    body: (statement_list))
+  (proc_declaration
+    name: (identifier)
+    (documentation_comment)
+    body: (statement_list)))
 
 ================================================================================
 Enum declarations

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -915,6 +915,9 @@ type
     D
     E
 
+  Complex = enum
+    X = when x: y else: z
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -979,4 +982,18 @@ type
             name: (identifier)))
         (enum_field_declaration
           (symbol_declaration
-            name: (identifier)))))))
+            name: (identifier)))))
+    (type_declaration
+      (type_symbol_declaration
+        name: (identifier))
+      (enum_declaration
+        (enum_field_declaration
+          (symbol_declaration
+            name: (identifier))
+          value: (when
+            condition: (identifier)
+            consequence: (statement_list
+              (identifier))
+            alternative: (else_branch
+              (statement_list
+                (identifier)))))))))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1559,6 +1559,7 @@ Cast expressions
 
 cast[int](x)
 cast(noSideEffect)
+cast(raises: [])
 
 --------------------------------------------------------------------------------
 
@@ -1567,7 +1568,11 @@ cast(noSideEffect)
     type: (identifier)
     value: (identifier))
   (cast
-    value: (identifier)))
+    value: (identifier))
+  (cast
+    value: (colon_expression
+      left: (identifier)
+      right: (array_construction))))
 
 ================================================================================
 Generalized strings

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -729,6 +729,44 @@ foo {x}
         (identifier)))))
 
 ================================================================================
+Dot generic calls
+================================================================================
+
+x.parseEnum[:T]
+
+x.parseEnum[:T](x, y)
+
+x.foo[:T, U, V]:
+  x
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (dot_generic_call
+    first_argument: (identifier)
+    function: (identifier)
+    generic_arguments: (generic_argument_list
+      (identifier)))
+  (dot_generic_call
+    first_argument: (identifier)
+    function: (identifier)
+    generic_arguments: (generic_argument_list
+      (identifier))
+    (argument_list
+      (identifier)
+      (identifier)))
+  (call
+    first_argument: (identifier)
+    function: (identifier)
+    generic_arguments: (generic_argument_list
+      (identifier)
+      (identifier)
+      (identifier))
+    (argument_list
+      (statement_list
+        (identifier)))))
+
+================================================================================
 Block statements
 ================================================================================
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -1328,6 +1328,8 @@ distinct int
 
 ptr ptr char
 
+(var int, var int)
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1341,6 +1343,13 @@ ptr ptr char
     (pointer_type)
     (modified_type
       (pointer_type)
+      (identifier)))
+  (tuple_construction
+    (modified_type
+      (var_type)
+      (identifier))
+    (modified_type
+      (var_type)
       (identifier))))
 
 ================================================================================

--- a/corpus/extras.txt
+++ b/corpus/extras.txt
@@ -61,6 +61,10 @@ echo x,
 Block comments
 ================================================================================
 
+#[
+  something
+]#
+
 echo x, #[comment]# y
 
 #[multi-line
@@ -76,6 +80,7 @@ Block doc is not ##[self-nesting]#, though
 --------------------------------------------------------------------------------
 
 (source_file
+  (block_comment)
   (call
     (identifier)
     (argument_list

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -410,3 +410,24 @@ static:
         (argument_list
           (identifier)
           (string_literal))))))
+
+================================================================================
+Assignment
+================================================================================
+
+x = foo.add proc =
+  bar
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (assignment
+    (identifier)
+    (call
+      (dot_expression
+        (identifier)
+        (identifier))
+      (argument_list
+        (proc_expression
+          (statement_list
+            (identifier)))))))

--- a/grammar.js
+++ b/grammar.js
@@ -1107,7 +1107,7 @@ module.exports = grammar({
       seq(
         keyword("cast"),
         field("type", optional(seq("[", $._type_expression, "]"))),
-        field("value", seq("(", $._expression, ")"))
+        field("value", seq("(", choice($._expression, $.colon_expression), ")"))
       ),
     parenthesized: $ =>
       choice(

--- a/grammar.js
+++ b/grammar.js
@@ -530,7 +530,7 @@ module.exports = grammar({
           $.symbol_declaration,
           // This should be _expression proper, but doing so inflates
           // the parser states to unusable.
-          optional(seq("=", field("value", $._simple_expression)))
+          optional(seq("=", field("value", $._expression)))
         )
       ),
     _tuple_declaration: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -8380,8 +8380,17 @@
                 "value": "("
               },
               {
-                "type": "SYMBOL",
-                "name": "_expression"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "colon_expression"
+                  }
+                ]
               },
               {
                 "type": "STRING",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1304,36 +1304,45 @@
       ]
     },
     "var_section": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "ALIAS",
-          "content": {
-            "type": "TOKEN",
+      "type": "PREC_DYNAMIC",
+      "value": 1,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "ALIAS",
             "content": {
-              "type": "PREC",
-              "value": 1,
+              "type": "TOKEN",
               "content": {
-                "type": "PATTERN",
-                "value": "v_?[aA]_?[rR]"
+                "type": "PREC",
+                "value": 1,
+                "content": {
+                  "type": "PATTERN",
+                  "value": "v_?[aA]_?[rR]"
+                }
               }
-            }
+            },
+            "named": false,
+            "value": "var"
           },
-          "named": false,
-          "value": "var"
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_variable_declaration_section"
-        }
-      ]
+          {
+            "type": "SYMBOL",
+            "name": "_variable_declaration_section"
+          }
+        ]
+      }
     },
     "_variable_declaration_section": {
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "variable_declaration"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_identifier_declaration"
+          },
+          "named": true,
+          "value": "variable_declaration"
         },
         {
           "type": "SEQ",
@@ -1348,8 +1357,13 @@
                 "type": "SEQ",
                 "members": [
                   {
-                    "type": "SYMBOL",
-                    "name": "variable_declaration"
+                    "type": "ALIAS",
+                    "content": {
+                      "type": "SYMBOL",
+                      "name": "_identifier_declaration"
+                    },
+                    "named": true,
+                    "value": "variable_declaration"
                   },
                   {
                     "type": "SYMBOL",
@@ -1365,10 +1379,6 @@
           ]
         }
       ]
-    },
-    "variable_declaration": {
-      "type": "SYMBOL",
-      "name": "_identifier_declaration"
     },
     "type_section": {
       "type": "SEQ",
@@ -10298,7 +10308,12 @@
       "name": "block_documentation_comment"
     }
   ],
-  "conflicts": [],
+  "conflicts": [
+    [
+      "var_type",
+      "var_section"
+    ]
+  ],
   "precedences": [
     [
       {
@@ -10436,16 +10451,6 @@
       {
         "type": "SYMBOL",
         "name": "_expression_statement"
-      }
-    ],
-    [
-      {
-        "type": "SYMBOL",
-        "name": "var_section"
-      },
-      {
-        "type": "SYMBOL",
-        "name": "var_type"
       }
     ],
     [

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1685,7 +1685,7 @@
                     "name": "value",
                     "content": {
                       "type": "SYMBOL",
-                      "name": "_simple_expression"
+                      "name": "_expression"
                     }
                   }
                 ]

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2561,6 +2561,15 @@
           "type": "ALIAS",
           "content": {
             "type": "SYMBOL",
+            "name": "_dot_generic_call_block"
+          },
+          "named": true,
+          "value": "dot_generic_call"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
             "name": "_infix_extended"
           },
           "named": true,
@@ -2592,6 +2601,24 @@
           },
           "named": true,
           "value": "call"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_complex_expression"
+          },
+          "named": true,
+          "value": "call"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_dot_generic_call_do"
+          },
+          "named": true,
+          "value": "dot_generic_call"
         }
       ]
     },
@@ -2772,6 +2799,10 @@
         {
           "type": "SYMBOL",
           "name": "_type_modifier"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dot_generic_call"
         },
         {
           "type": "ALIAS",
@@ -3413,6 +3444,10 @@
         {
           "type": "SYMBOL",
           "name": "_call_block"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_dot_generic_call_block"
         }
       ]
     },
@@ -3539,6 +3574,24 @@
         ]
       }
     },
+    "_dot_generic_call_block": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_dot_generic_head"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_call_block_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
     "_call_block": {
       "type": "SEQ",
       "members": [
@@ -3579,6 +3632,24 @@
         {
           "type": "SYMBOL",
           "name": "_post_expression_block"
+        }
+      ]
+    },
+    "_dot_generic_call_do": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_dot_generic_head"
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_call_do_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
         }
       ]
     },
@@ -3695,6 +3766,32 @@
         }
       ]
     },
+    "_command_complex_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_basic_expression"
+          }
+        },
+        {
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_command_complex_expression_argument_list"
+          },
+          "named": true,
+          "value": "argument_list"
+        }
+      ]
+    },
+    "_command_complex_expression_argument_list": {
+      "type": "SYMBOL",
+      "name": "_expression_with_call_do"
+    },
     "_command_expression": {
       "type": "SEQ",
       "members": [
@@ -3723,6 +3820,119 @@
         {
           "type": "SYMBOL",
           "name": "_simple_expression_command_start"
+        }
+      ]
+    },
+    "dot_generic_call": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "_dot_generic_head"
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "ALIAS",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_call_argument_list"
+                },
+                "named": true,
+                "value": "argument_list"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "_dot_generic_head": {
+      "type": "PREC",
+      "value": "suffix",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "FIELD",
+            "name": "first_argument",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_basic_expression"
+            }
+          },
+          {
+            "type": "STRING",
+            "value": "."
+          },
+          {
+            "type": "FIELD",
+            "name": "function",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_symbol"
+            }
+          },
+          {
+            "type": "FIELD",
+            "name": "generic_arguments",
+            "content": {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_dot_generic_argument_list"
+              },
+              "named": true,
+              "value": "generic_argument_list"
+            }
+          }
+        ]
+      }
+    },
+    "_dot_generic_argument_list": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "IMMEDIATE_TOKEN",
+          "content": {
+            "type": "STRING",
+            "value": "[:"
+          }
+        },
+        {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_expression"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": ","
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_expression"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
         }
       ]
     },
@@ -10416,6 +10626,26 @@
       {
         "type": "SYMBOL",
         "name": "_command_statement"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_simple_expression_command_start"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_command_complex_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_equal_expression_list"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "_command_complex_expression_argument_list"
       }
     ]
   ],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1831,6 +1831,10 @@
             "named": true
           },
           {
+            "type": "colon_expression",
+            "named": true
+          },
+          {
             "type": "curly_construction",
             "named": true
           },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4219,11 +4219,19 @@
             "named": true
           },
           {
+            "type": "block",
+            "named": true
+          },
+          {
             "type": "bracket_expression",
             "named": true
           },
           {
             "type": "call",
+            "named": true
+          },
+          {
+            "type": "case",
             "named": true
           },
           {
@@ -4267,6 +4275,14 @@
             "named": true
           },
           {
+            "type": "for",
+            "named": true
+          },
+          {
+            "type": "func_expression",
+            "named": true
+          },
+          {
             "type": "generalized_string",
             "named": true
           },
@@ -4275,11 +4291,19 @@
             "named": true
           },
           {
+            "type": "if",
+            "named": true
+          },
+          {
             "type": "infix_expression",
             "named": true
           },
           {
             "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "iterator_expression",
             "named": true
           },
           {
@@ -4319,6 +4343,10 @@
             "named": true
           },
           {
+            "type": "proc_expression",
+            "named": true
+          },
+          {
             "type": "proc_type",
             "named": true
           },
@@ -4331,6 +4359,10 @@
             "named": true
           },
           {
+            "type": "try",
+            "named": true
+          },
+          {
             "type": "tuple_construction",
             "named": true
           },
@@ -4340,6 +4372,10 @@
           },
           {
             "type": "var_type",
+            "named": true
+          },
+          {
+            "type": "when",
             "named": true
           }
         ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -83,6 +83,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "elif_branch",
           "named": true
         },
@@ -290,6 +294,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -487,6 +495,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -626,6 +638,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -852,6 +868,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -1006,6 +1026,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -1124,9 +1148,9 @@
     "type": "call",
     "named": true,
     "fields": {
-      "function": {
+      "first_argument": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "accent_quoted",
@@ -1170,6 +1194,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -1253,6 +1281,150 @@
             "named": true
           }
         ]
+      },
+      "function": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "accent_quoted",
+            "named": true
+          },
+          {
+            "type": "array_construction",
+            "named": true
+          },
+          {
+            "type": "bracket_expression",
+            "named": true
+          },
+          {
+            "type": "call",
+            "named": true
+          },
+          {
+            "type": "cast",
+            "named": true
+          },
+          {
+            "type": "char_literal",
+            "named": true
+          },
+          {
+            "type": "curly_construction",
+            "named": true
+          },
+          {
+            "type": "curly_expression",
+            "named": true
+          },
+          {
+            "type": "custom_numeric_literal",
+            "named": true
+          },
+          {
+            "type": "distinct_type",
+            "named": true
+          },
+          {
+            "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
+            "type": "enum_type",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "generalized_string",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "modified_type",
+            "named": true
+          },
+          {
+            "type": "nil_literal",
+            "named": true
+          },
+          {
+            "type": "object_type",
+            "named": true
+          },
+          {
+            "type": "out_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized",
+            "named": true
+          },
+          {
+            "type": "pointer_type",
+            "named": true
+          },
+          {
+            "type": "pragma_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "proc_type",
+            "named": true
+          },
+          {
+            "type": "ref_type",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "tuple_construction",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "var_type",
+            "named": true
+          }
+        ]
+      },
+      "generic_arguments": {
+        "multiple": false,
+        "required": false,
+        "types": [
+          {
+            "type": "generic_argument_list",
+            "named": true
+          }
+        ]
       }
     },
     "children": {
@@ -1324,6 +1496,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -1521,6 +1697,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -1668,6 +1848,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -1854,6 +2038,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -1993,6 +2181,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -2222,6 +2414,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -2420,6 +2616,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -2656,6 +2856,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -2815,6 +3019,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -2989,6 +3197,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -3140,6 +3352,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -3329,6 +3545,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -3479,6 +3699,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -3577,6 +3801,180 @@
     }
   },
   {
+    "type": "dot_generic_call",
+    "named": true,
+    "fields": {
+      "first_argument": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "accent_quoted",
+            "named": true
+          },
+          {
+            "type": "array_construction",
+            "named": true
+          },
+          {
+            "type": "bracket_expression",
+            "named": true
+          },
+          {
+            "type": "call",
+            "named": true
+          },
+          {
+            "type": "cast",
+            "named": true
+          },
+          {
+            "type": "char_literal",
+            "named": true
+          },
+          {
+            "type": "curly_construction",
+            "named": true
+          },
+          {
+            "type": "curly_expression",
+            "named": true
+          },
+          {
+            "type": "custom_numeric_literal",
+            "named": true
+          },
+          {
+            "type": "distinct_type",
+            "named": true
+          },
+          {
+            "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
+            "type": "enum_type",
+            "named": true
+          },
+          {
+            "type": "float_literal",
+            "named": true
+          },
+          {
+            "type": "generalized_string",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          },
+          {
+            "type": "integer_literal",
+            "named": true
+          },
+          {
+            "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "modified_type",
+            "named": true
+          },
+          {
+            "type": "nil_literal",
+            "named": true
+          },
+          {
+            "type": "object_type",
+            "named": true
+          },
+          {
+            "type": "out_type",
+            "named": true
+          },
+          {
+            "type": "parenthesized",
+            "named": true
+          },
+          {
+            "type": "pointer_type",
+            "named": true
+          },
+          {
+            "type": "pragma_expression",
+            "named": true
+          },
+          {
+            "type": "prefix_expression",
+            "named": true
+          },
+          {
+            "type": "proc_type",
+            "named": true
+          },
+          {
+            "type": "ref_type",
+            "named": true
+          },
+          {
+            "type": "string_literal",
+            "named": true
+          },
+          {
+            "type": "tuple_construction",
+            "named": true
+          },
+          {
+            "type": "tuple_type",
+            "named": true
+          },
+          {
+            "type": "var_type",
+            "named": true
+          }
+        ]
+      },
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "accent_quoted",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      },
+      "generic_arguments": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "generic_argument_list",
+            "named": true
+          }
+        ]
+      }
+    },
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "argument_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "elif_branch",
     "named": true,
     "fields": {
@@ -3634,6 +4032,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -3853,6 +4255,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -4008,6 +4414,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -4147,6 +4557,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -4367,6 +4781,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -4569,6 +4987,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -4740,6 +5162,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -4883,6 +5309,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -5138,6 +5568,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -5372,6 +5806,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -5556,6 +5994,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -5667,6 +6109,185 @@
     }
   },
   {
+    "type": "generic_argument_list",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "accent_quoted",
+          "named": true
+        },
+        {
+          "type": "array_construction",
+          "named": true
+        },
+        {
+          "type": "block",
+          "named": true
+        },
+        {
+          "type": "bracket_expression",
+          "named": true
+        },
+        {
+          "type": "call",
+          "named": true
+        },
+        {
+          "type": "case",
+          "named": true
+        },
+        {
+          "type": "cast",
+          "named": true
+        },
+        {
+          "type": "char_literal",
+          "named": true
+        },
+        {
+          "type": "curly_construction",
+          "named": true
+        },
+        {
+          "type": "curly_expression",
+          "named": true
+        },
+        {
+          "type": "custom_numeric_literal",
+          "named": true
+        },
+        {
+          "type": "distinct_type",
+          "named": true
+        },
+        {
+          "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
+          "type": "enum_type",
+          "named": true
+        },
+        {
+          "type": "float_literal",
+          "named": true
+        },
+        {
+          "type": "for",
+          "named": true
+        },
+        {
+          "type": "func_expression",
+          "named": true
+        },
+        {
+          "type": "generalized_string",
+          "named": true
+        },
+        {
+          "type": "identifier",
+          "named": true
+        },
+        {
+          "type": "if",
+          "named": true
+        },
+        {
+          "type": "infix_expression",
+          "named": true
+        },
+        {
+          "type": "integer_literal",
+          "named": true
+        },
+        {
+          "type": "iterator_expression",
+          "named": true
+        },
+        {
+          "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "modified_type",
+          "named": true
+        },
+        {
+          "type": "nil_literal",
+          "named": true
+        },
+        {
+          "type": "object_type",
+          "named": true
+        },
+        {
+          "type": "out_type",
+          "named": true
+        },
+        {
+          "type": "parenthesized",
+          "named": true
+        },
+        {
+          "type": "pointer_type",
+          "named": true
+        },
+        {
+          "type": "pragma_expression",
+          "named": true
+        },
+        {
+          "type": "prefix_expression",
+          "named": true
+        },
+        {
+          "type": "proc_expression",
+          "named": true
+        },
+        {
+          "type": "proc_type",
+          "named": true
+        },
+        {
+          "type": "ref_type",
+          "named": true
+        },
+        {
+          "type": "string_literal",
+          "named": true
+        },
+        {
+          "type": "try",
+          "named": true
+        },
+        {
+          "type": "tuple_construction",
+          "named": true
+        },
+        {
+          "type": "tuple_type",
+          "named": true
+        },
+        {
+          "type": "var_type",
+          "named": true
+        },
+        {
+          "type": "when",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "generic_parameter_list",
     "named": true,
     "fields": {},
@@ -5753,6 +6374,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -5942,6 +6567,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -6125,6 +6754,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -6315,6 +6948,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -6515,6 +7152,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -6758,6 +7399,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -6942,6 +7587,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -7103,6 +7752,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -7327,6 +7980,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -7543,6 +8200,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -7739,6 +8400,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_declaration",
           "named": true
         },
@@ -7888,6 +8553,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -8095,6 +8764,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -8238,6 +8911,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -8513,6 +9190,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -8784,6 +9465,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -8939,6 +9624,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -9214,6 +9903,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "elif_branch",
           "named": true
         },
@@ -9443,6 +10136,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -9627,6 +10324,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -9791,6 +10492,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -9936,6 +10641,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -10130,6 +10839,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -10274,6 +10987,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -10481,6 +11198,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -10768,6 +11489,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -11187,6 +11912,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -11374,6 +12103,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -11666,6 +12399,10 @@
           "named": true
         },
         {
+          "type": "dot_generic_call",
+          "named": true
+        },
+        {
           "type": "enum_type",
           "named": true
         },
@@ -11872,6 +12609,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -12147,6 +12888,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -12290,6 +13035,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -12498,6 +13247,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -12641,6 +13394,10 @@
           },
           {
             "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "dot_generic_call",
             "named": true
           },
           {
@@ -12844,6 +13601,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -13032,6 +13793,10 @@
             "named": true
           },
           {
+            "type": "dot_generic_call",
+            "named": true
+          },
+          {
             "type": "enum_type",
             "named": true
           },
@@ -13177,6 +13942,10 @@
         },
         {
           "type": "dot_expression",
+          "named": true
+        },
+        {
+          "type": "dot_generic_call",
           "named": true
         },
         {
@@ -13356,6 +14125,10 @@
   },
   {
     "type": "[",
+    "named": false
+  },
+  {
+    "type": "[:",
     "named": false
   },
   {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -811,7 +811,7 @@ bool lex_indent(Context& ctx)
 
   if (ctx.valid(TokenType::LayoutEmpty) &&
       ctx.state().test_flag(Flag::AfterNewline) &&
-      current_layout == line_indent) {
+      (current_layout >= line_indent || ctx.eof())) {
     ctx.mark_end();
     return ctx.finish(TokenType::LayoutEmpty);
   }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -900,7 +900,10 @@ loop_end:
 
 bool lex_init(Context& ctx)
 {
-  if (!ctx.state().layout_stack.empty() || ctx.error()) {
+  if (!ctx.state().layout_stack.empty() || ctx.error() ||
+      ctx.any_valid(make_valid_symbols(
+          {TokenType::BlockCommentContent,
+           TokenType::BlockDocCommentContent}))) {
     return false;
   }
 


### PR DESCRIPTION
This PR brings support for more complex Nim structure, enabled by the parser size reduction effort done by earlier PRs.

However, as a result of this, generating the parser is now costlier at 7GiB of memory. The resulting parser is /slightly/ smaller at 118MiB.

New structures supported:
- Command call with full-fledged expression as arguments
- Full expression support in enum value declarations
- `(var T, var U)` within typedesc
- `cast(raises: [])`

Fixed bugs:
- `layout_empty` not emitted for lower indentation levels
- Block comments may mess up initial indentation determination