### PR TITLE
scanner: unconditional layout termination at pair ends

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -207,19 +207,8 @@ module.exports = grammar({
     $._layout_end,
     $._layout_terminator,
     $._layout_empty,
-    // These are tokens to track layout closes.
-    // Enabling all of these will create an unusable parser due to
-    // excessive amount of states.
     // @ts-ignore: DSL not updated for literals
     ",",
-    // @ts-ignore: DSL not updated for literals
-    ")",
-    // @ts-ignore: DSL not updated for literals
-    "]",
-    // @ts-ignore: DSL not updated for literals
-    "}",
-    // @ts-ignore: DSL not updated for literals
-    ".}",
     $._synchronize,
     $._invalid_layout,
     $._sigil_operator,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10697,22 +10697,6 @@
       "value": ","
     },
     {
-      "type": "STRING",
-      "value": ")"
-    },
-    {
-      "type": "STRING",
-      "value": "]"
-    },
-    {
-      "type": "STRING",
-      "value": "}"
-    },
-    {
-      "type": "STRING",
-      "value": ".}"
-    },
-    {
       "type": "SYMBOL",
       "name": "_synchronize"
     },

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -40,10 +40,6 @@ enum class TokenType : TSSymbol {
   LayoutTerminator,
   LayoutEmpty,
   Comma,
-  ParenClose,
-  BracketClose,
-  CurlyClose,
-  CurlyDotClose,
   Synchronize,
   InvalidLayout,
   SigilOp,
@@ -322,7 +318,7 @@ constexpr char32_t to_upper(char32_t chr)
   return is_lower(chr) ? chr & ~lower_case_bit : chr;
 }
 
-bool lex_inline_layout(Context& ctx, bool read_dot = false)
+bool lex_inline_layout(Context& ctx)
 {
   if (ctx.state().layout_stack.empty()) {
     return false;
@@ -346,30 +342,12 @@ bool lex_inline_layout(Context& ctx, bool read_dot = false)
     }
     break;
   case ')':
-    if (ctx.valid(TokenType::ParenClose)) {
-      return false;
-    }
-    break;
   case ']':
-    if (ctx.valid(TokenType::BracketClose)) {
-      return false;
-    }
-    break;
   case '}':
-    if ((!read_dot && ctx.valid(TokenType::CurlyClose)) ||
-        (read_dot && ctx.valid(TokenType::CurlyDotClose))) {
-      return false;
-    }
     break;
   case '.':
-    if (!read_dot) {
-      ctx.advance();
-      if (ctx.lookahead() == '}') {
-        if (ctx.valid(TokenType::CurlyDotClose)) {
-          return false;
-        }
-        break;
-      }
+    if (ctx.advance() == '}') {
+      break;
     }
     return false;
   default:
@@ -551,7 +529,7 @@ bool lex(Context& ctx, bool immediate)
 
   if (result == TokenType::TokenTypeLen) {
     if (is_dot) {
-      TRY_LEXN(ctx, lex_inline_layout, true);
+      TRY_LEX(ctx, lex_inline_layout);
     }
     return false;
   }


### PR DESCRIPTION
Since `)`, `]`, `}` and `.}` are paired, there is no need to verify whether those tokens are being expected. Instead we can rely solely on whether layout termination is expected.

To visualize this idea, we use `{` and `}` as layout_start and end, with `;` being layout_terminator:

```
  if foo:
    {
    (foo)
    #   ^ a `)` is expected, and none of `;` or `}` is
    #     expected here.
    }

  if bar:
    {
    (if x:
      {
      y;})
    #  ^ as `{` was emitted, `;` and/or `}` is expected
    #    and `)` won't be expected.
    }
```

In the two possible cases, it is observed that whenever `)` is expected, neither `;` nor `}` will be expected, and vice versa. Thus there is no need to check the status of these closing tokens.

With this change, the parser is now 60MiB and only requires 7GiB of RAM to generate.