### PR TITLE
split * and : into two tokens

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -239,6 +239,9 @@ var z, w: float
 var (c, d) = (2, 3)
 var (x, ) = (1, )
 
+var x*:int
+var y *: float
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -305,7 +308,23 @@ var (x, ) = (1, )
           (symbol_declaration
             name: (identifier))))
       value: (tuple_construction
-        (integer_literal)))))
+        (integer_literal))))
+  (var_section
+    (variable_declaration
+      (symbol_declaration_list
+        (symbol_declaration
+          name: (exported_symbol
+            (identifier))))
+      type: (type_expression
+        (identifier))))
+  (var_section
+    (variable_declaration
+      (symbol_declaration_list
+        (symbol_declaration
+          name: (exported_symbol
+            (identifier))))
+      type: (type_expression
+        (identifier)))))
 
 ================================================================================
 Type aliases

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -53,6 +53,8 @@ not a.c
 
 echo $a
 
+*:bar
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -97,7 +99,11 @@ echo $a
     (argument_list
       (prefix_expression
         operator: (operator)
-        (identifier)))))
+        (identifier))))
+  (prefix_expression
+    operator: (operator)
+    (ERROR)
+    (identifier)))
 
 ================================================================================
 Infix expressions

--- a/grammar.js
+++ b/grammar.js
@@ -131,7 +131,6 @@ const InfixOperators = {
   L9: token(
     seq(
       choice(
-        "*",
         "%",
         "\\",
         "/"
@@ -152,6 +151,7 @@ const InfixOperators = {
       repeat(choice(...Operators))
     )
   ),
+  L9Star: token(seq("*", repeat(choice(...Operators.filter(x => x != ":"))))),
   L8: token(
     seq(
       choice(
@@ -208,6 +208,7 @@ module.exports = grammar({
     $._invalid_layout,
     $._sigil_operator,
     $._prefix_operator,
+    $._symbol_export_marker,
     $._case_of,
   ],
 
@@ -1042,6 +1043,7 @@ module.exports = grammar({
           [$._infix_operator_10r, "binary_10", prec.right],
           [$._infix_operator_10l, "binary_10", prec.left],
           [$._infix_operator_9, "binary_9", prec.left],
+          [$._infix_operator_9_star, "binary_9", prec.left],
           [
             choice(...WordOperators[9].map(x => keyword(x))),
             "binary_9",
@@ -1087,6 +1089,7 @@ module.exports = grammar({
     _infix_operator_10r: $ => alias(InfixOperators.R10, $.operator),
     _infix_operator_10l: $ => alias(InfixOperators.L10, $.operator),
     _infix_operator_9: $ => alias(InfixOperators.L9, $.operator),
+    _infix_operator_9_star: $ => alias(InfixOperators.L9Star, $.operator),
     _infix_operator_8: $ => alias(InfixOperators.L8, $.operator),
     _infix_operator_7: $ => alias(InfixOperators.L7, $.operator),
     _infix_operator_6: $ => alias(InfixOperators.L6, $.operator),
@@ -1310,7 +1313,8 @@ module.exports = grammar({
         field("name", choice($._symbol, $.exported_symbol)),
         optional($.pragma_list)
       ),
-    exported_symbol: $ => seq($._symbol, "*"),
+    exported_symbol: $ => seq($._symbol, alias($._symbol_export_marker, "*")),
+    _symbol_export_marker: () => "*",
 
     /* Literals */
     _literal: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -5044,6 +5044,39 @@
                 "type": "FIELD",
                 "name": "operator",
                 "content": {
+                  "type": "SYMBOL",
+                  "name": "_infix_operator_9_star"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "right",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_simple_expression"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": "binary_9",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "left",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "_simple_expression"
+                }
+              },
+              {
+                "type": "FIELD",
+                "name": "operator",
+                "content": {
                   "type": "CHOICE",
                   "members": [
                     {
@@ -6028,10 +6061,6 @@
               "members": [
                 {
                   "type": "STRING",
-                  "value": "*"
-                },
-                {
-                  "type": "STRING",
                   "value": "%"
                 },
                 {
@@ -6120,6 +6149,103 @@
                   {
                     "type": "STRING",
                     "value": ":"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "\\"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "named": true,
+      "value": "operator"
+    },
+    "_infix_operator_9_star": {
+      "type": "ALIAS",
+      "content": {
+        "type": "TOKEN",
+        "content": {
+          "type": "SEQ",
+          "members": [
+            {
+              "type": "STRING",
+              "value": "*"
+            },
+            {
+              "type": "REPEAT",
+              "content": {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "="
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "+"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "-"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "*"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "/"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "<"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": ">"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "@"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "$"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "~"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "&"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "%"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "|"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "!"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "?"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "^"
+                  },
+                  {
+                    "type": "STRING",
+                    "value": "."
                   },
                   {
                     "type": "STRING",
@@ -7572,10 +7698,6 @@
                     "members": [
                       {
                         "type": "STRING",
-                        "value": "*"
-                      },
-                      {
-                        "type": "STRING",
                         "value": "%"
                       },
                       {
@@ -7664,6 +7786,98 @@
                         {
                           "type": "STRING",
                           "value": ":"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "\\"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "TOKEN",
+              "content": {
+                "type": "SEQ",
+                "members": [
+                  {
+                    "type": "STRING",
+                    "value": "*"
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "STRING",
+                          "value": "="
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "+"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "-"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "*"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "/"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "<"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": ">"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "@"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "$"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "~"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "&"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "%"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "|"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "!"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "?"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "^"
+                        },
+                        {
+                          "type": "STRING",
+                          "value": "."
                         },
                         {
                           "type": "STRING",
@@ -9750,10 +9964,19 @@
           "name": "_symbol"
         },
         {
-          "type": "STRING",
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_symbol_export_marker"
+          },
+          "named": false,
           "value": "*"
         }
       ]
+    },
+    "_symbol_export_marker": {
+      "type": "STRING",
+      "value": "*"
     },
     "_literal": {
       "type": "CHOICE",
@@ -10946,6 +11169,10 @@
     {
       "type": "SYMBOL",
       "name": "_prefix_operator"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_symbol_export_marker"
     },
     {
       "type": "SYMBOL",


### PR DESCRIPTION
This is required to correctly handle `var x *: typ`.

This does require some external parser changes to avoid `*` being consumed as unary when exported symbol is a valid interpretation.

Fixes https://github.com/alaviss/tree-sitter-nim/issues/35