### PR TITLE
allow symbol_declaration_list to harbor a trailing comma

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -872,6 +872,10 @@ proc bar =
 proc foo =
   ## comment
 
+proc trailing(x,)
+
+proc trailing_fun(x, y,: float)
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -989,7 +993,25 @@ proc foo =
   (proc_declaration
     name: (identifier)
     (documentation_comment)
-    body: (statement_list)))
+    body: (statement_list))
+  (proc_declaration
+    name: (identifier)
+    parameters: (parameter_declaration_list
+      (parameter_declaration
+        (symbol_declaration_list
+          (symbol_declaration
+            name: (identifier))))))
+  (proc_declaration
+    name: (identifier)
+    parameters: (parameter_declaration_list
+      (parameter_declaration
+        (symbol_declaration_list
+          (symbol_declaration
+            name: (identifier))
+          (symbol_declaration
+            name: (identifier)))
+        type: (type_expression
+          (identifier))))))
 
 ================================================================================
 Enum declarations

--- a/grammar.js
+++ b/grammar.js
@@ -1296,7 +1296,13 @@ module.exports = grammar({
       ),
     symbol_declaration_list: $ =>
       prec.right(
-        sep1(choice($.symbol_declaration, $.tuple_deconstruct_declaration), ",")
+        seq(
+          sep1(
+            choice($.symbol_declaration, $.tuple_deconstruct_declaration),
+            ","
+          ),
+          optional(",")
+        )
       ),
     tuple_deconstruct_declaration: $ =>
       seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9814,42 +9814,59 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "symbol_declaration"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "symbol_declaration"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "tuple_deconstruct_declaration"
+                  }
+                ]
               },
               {
-                "type": "SYMBOL",
-                "name": "tuple_deconstruct_declaration"
+                "type": "REPEAT",
+                "content": {
+                  "type": "SEQ",
+                  "members": [
+                    {
+                      "type": "STRING",
+                      "value": ","
+                    },
+                    {
+                      "type": "CHOICE",
+                      "members": [
+                        {
+                          "type": "SYMBOL",
+                          "name": "symbol_declaration"
+                        },
+                        {
+                          "type": "SYMBOL",
+                          "name": "tuple_deconstruct_declaration"
+                        }
+                      ]
+                    }
+                  ]
+                }
               }
             ]
           },
           {
-            "type": "REPEAT",
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "STRING",
-                  "value": ","
-                },
-                {
-                  "type": "CHOICE",
-                  "members": [
-                    {
-                      "type": "SYMBOL",
-                      "name": "symbol_declaration"
-                    },
-                    {
-                      "type": "SYMBOL",
-                      "name": "tuple_deconstruct_declaration"
-                    }
-                  ]
-                }
-              ]
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           }
         ]
       }


### PR DESCRIPTION
This seems to be a grammar quirk of Nim.

Verified against Nim 2.0.0.

Fixes https://github.com/alaviss/tree-sitter-nim/issues/38