### PR TITLE
grammar, scanner: better error recovery

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -410,6 +410,13 @@ type
   E = object
     when foo: x: int
 
+type
+  Unfinished = object
+    when x:
+
+    case foo: bar
+    of a: string
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -629,7 +636,31 @@ type
                   (symbol_declaration
                     name: (identifier)))
                 type: (type_expression
-                  (identifier))))))))))
+                  (identifier)))))))))
+  (type_section
+    (type_declaration
+      (type_symbol_declaration
+        name: (identifier))
+      (object_declaration
+        (field_declaration_list
+          (conditional_declaration
+            condition: (identifier)
+            consequence: (field_declaration_list))
+          (variant_declaration
+            (variant_discriminator_declaration
+              (symbol_declaration_list
+                (symbol_declaration
+                  name: (identifier)))
+              type: (type_expression
+                (identifier)))
+            (of_branch
+              values: (expression_list
+                (identifier))
+              (field_declaration_list
+                (field_declaration
+                  (symbol_declaration_list
+                    (symbol_declaration
+                      name: (identifier))))))))))))
 
 ================================================================================
 Tuple declarations

--- a/corpus/errors.txt
+++ b/corpus/errors.txt
@@ -1,0 +1,25 @@
+================================================================================
+Error within variant object declaration
+================================================================================
+
+type
+  E = object
+    case foo
+    of bar
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (type_section
+    (type_declaration
+      (type_symbol_declaration
+        (identifier))
+      (object_declaration
+        (field_declaration_list
+          (variant_declaration
+            (variant_discriminator_declaration
+              (symbol_declaration_list
+                (symbol_declaration
+                  (identifier)))))
+          (ERROR
+            (identifier)))))))

--- a/grammar.js
+++ b/grammar.js
@@ -600,7 +600,11 @@ module.exports = grammar({
       ),
 
     _object_field_declaration_branch_list: $ =>
-      choice($._object_field_declaration, $._object_field_declaration_list),
+      choice(
+        $._object_field_declaration,
+        $._object_field_declaration_list,
+        $._layout_empty
+      ),
     _object_field_declaration_list: $ =>
       seq(
         $._layout_start,
@@ -659,7 +663,7 @@ module.exports = grammar({
         seq(
           $.variant_discriminator_declaration,
           optional(":"),
-          repeat1(alias($._of_declaration_branch, $.of_branch)),
+          repeat(alias($._of_declaration_branch, $.of_branch)),
           optional(alias($._else_declaration_branch, $.else_branch))
         )
       ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2078,6 +2078,10 @@
         {
           "type": "SYMBOL",
           "name": "_object_field_declaration_list"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "_layout_empty"
         }
       ]
     },
@@ -2331,7 +2335,7 @@
             ]
           },
           {
-            "type": "REPEAT1",
+            "type": "REPEAT",
             "content": {
               "type": "ALIAS",
               "content": {

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -814,7 +814,11 @@ bool lex_indent(Context& ctx)
     return ctx.finish(TokenType::LayoutStart);
   }
 
-  if (ctx.valid(TokenType::LayoutEmpty) &&
+  // LayoutEmpty has to be explicitly requested, and errors generally
+  // don't happen within the contexts it would be requested.
+  //
+  // Don't emit them on errors to prevent mangling error recovery.
+  if (!ctx.error() && ctx.valid(TokenType::LayoutEmpty) &&
       ctx.state().test_flag(Flag::AfterNewline) &&
       (current_layout >= line_indent || ctx.eof())) {
     ctx.mark_end();


### PR DESCRIPTION
A couple improvements to error recovery:

- `case` and `when` within an object can now tolerate incomplete code. This change was done to match what is done for them outside of an object declaration.
- `scanner.cc` will no longer emit `layout_empty` during error recovery, which should prevent some extreme interpretation due to `layout_empty` being valid in only a handful of places.

  Example:

  ```nim
  type
    X = object
      case y
      of x
  ```
  
  Before:
  
  ```
  (source_file [0, 0] - [4, 0]
    (ERROR [0, 0] - [4, 0]
      (type_symbol_declaration [1, 2] - [1, 3]
        name: (identifier [1, 2] - [1, 3]))
      (variant_discriminator_declaration [2, 9] - [2, 10]
        (symbol_declaration_list [2, 9] - [2, 10]
          (symbol_declaration [2, 9] - [2, 10]
            name: (identifier [2, 9] - [2, 10]))))
      (identifier [3, 7] - [3, 8])))
  ```
  
  After:
  
  ```
  (source_file [0, 0] - [4, 0]
    (type_section [0, 0] - [4, 0]
      (type_declaration [1, 2] - [4, 0]
        (type_symbol_declaration [1, 2] - [1, 3]
          name: (identifier [1, 2] - [1, 3]))
        (object_declaration [1, 6] - [4, 0]
          (field_declaration_list [2, 4] - [4, 0]
            (variant_declaration [2, 4] - [2, 10]
              (variant_discriminator_declaration [2, 9] - [2, 10]
                (symbol_declaration_list [2, 9] - [2, 10]
                  (symbol_declaration [2, 9] - [2, 10]
                    name: (identifier [2, 9] - [2, 10])))))
            (ERROR [3, 4] - [3, 8]
              (identifier [3, 7] - [3, 8])))))))
  ```

Ref: https://github.com/nvim-treesitter/nvim-treesitter/pull/5437#issuecomment-1731943050