### PR TITLE
major behavior changes to layouting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/prettierrc.json",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "trailingComma": "es5"
 }

--- a/corpus/errors.txt
+++ b/corpus/errors.txt
@@ -22,4 +22,38 @@ type
                 (symbol_declaration
                   (identifier)))))
           (ERROR
-            (identifier)))))))
+            (identifier)))))
+    (MISSING _layout_end)))
+
+================================================================================
+Error within statements with body
+================================================================================
+
+if true:
+  while
+
+if true:
+  while true:
+    try: x
+    except:
+      let
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (if
+    (identifier)
+    (statement_list
+      (ERROR)))
+  (if
+    (identifier)
+    (statement_list
+      (while
+        (identifier)
+        (statement_list
+          (try
+            (statement_list
+              (identifier))
+            (except_branch
+              (statement_list
+                (ERROR)))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -397,7 +397,7 @@ module.exports = grammar({
 
     _line_statement_list: $ => prec.right(sep1($._simple_statement, ";")),
     _block_statement_list: $ =>
-      seq($._layout_start, $._semi_statement_list, $._layout_end),
+      seq($._layout_start, optional($._semi_statement_list), $._layout_end),
 
     _semi_statement_list: $ =>
       repeat1(seq($._statement, choice(";", $._layout_terminator))),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -68,8 +68,16 @@
           "name": "_layout_start"
         },
         {
-          "type": "SYMBOL",
-          "name": "_semi_statement_list"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_semi_statement_list"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "SYMBOL",


### PR DESCRIPTION
* Layouts are ended when it is detected that such event happens
  regardless of whether it is correct to do so. This allows for
  stronger error recovery as the parser can reliably detect where
  a layout ends.

* Layouts now terminates at the end of each statements or blocks, rather
  than collecting up to the next statement.

* Layout termination now plays a lot nicer in recovery scenarios by
  issuing a forced change to the scanner state. This makes the parser
  respects layout termination during recovery, resulting in much better
  syntax tree on errors.

* The body of an indented statement list is now optional. While this
  construct cannot be generated by normal means as the scanner must see
  content to even start a block, they can happen due to errors within
  the block. Allowing the block to be empty in this case gives
  tree-sitter a safe avenue to rollback instead of rolling back the
  entire large structure, which can be seen in https://github.com/alaviss/tree-sitter-nim/issues/42

Fixes https://github.com/alaviss/tree-sitter-nim/issues/42
Fixes https://github.com/alaviss/tree-sitter-nim/issues/45