### PR TITLE
improve capture queries by specializing types

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -159,7 +159,8 @@ const Test* {.importc: "TEST".}: int
           (pragma_list
             (colon_expression
               left: (identifier)
-              right: (string_literal)))))
+              right: (string_literal
+                (string_content))))))
       type: (type_expression
         (identifier)))))
 
@@ -584,7 +585,8 @@ type
           (identifier)
           (colon_expression
             left: (identifier)
-            right: (string_literal))))
+            right: (string_literal
+              (string_content)))))
       (ref_type
         (object_declaration
           inherits: (type_expression
@@ -607,7 +609,8 @@ type
                   (pragma_list
                     (colon_expression
                       left: (identifier)
-                      right: (string_literal)))))
+                      right: (string_literal
+                        (string_content))))))
               type: (type_expression
                 (bracket_expression
                   left: (identifier)
@@ -971,7 +974,8 @@ proc trailing_fun(x, y,: float)
       (call
         function: (identifier)
         (argument_list
-          (string_literal)))))
+          (string_literal
+            (string_content))))))
   (iterator_declaration
     name: (identifier)
     parameters: (parameter_declaration_list
@@ -1095,11 +1099,13 @@ type
         (enum_field_declaration
           (symbol_declaration
             name: (identifier))
-          value: (string_literal))
+          value: (string_literal
+            (string_content)))
         (enum_field_declaration
           (symbol_declaration
             name: (identifier))
-          value: (string_literal))))
+          value: (string_literal
+            (string_content)))))
     (type_declaration
       (type_symbol_declaration
         name: (identifier))
@@ -1113,7 +1119,8 @@ type
         (enum_field_declaration
           (symbol_declaration
             name: (identifier))
-          value: (string_literal))))
+          value: (string_literal
+            (string_content)))))
     (type_declaration
       (type_symbol_declaration
         name: (identifier))

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -845,8 +845,10 @@ type
         refines: (refinement_list
           (type_expression
             (identifier)))
-        (comment)
-        (comment)
+        (comment
+          (comment_content))
+        (comment
+          (comment_content))
         body: (statement_list
           (infix_expression
             left: (call
@@ -1023,11 +1025,13 @@ proc trailing_fun(x, y,: float)
     name: (identifier))
   (proc_declaration
     name: (identifier)
-    (documentation_comment)
+    (documentation_comment
+      (comment_content))
     body: (statement_list))
   (proc_declaration
     name: (identifier)
-    (documentation_comment)
+    (documentation_comment
+      (comment_content))
     body: (statement_list))
   (proc_declaration
     name: (identifier)

--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -159,7 +159,7 @@ const Test* {.importc: "TEST".}: int
           (pragma_list
             (colon_expression
               left: (identifier)
-              right: (string_literal
+              right: (interpreted_string_literal
                 (string_content))))))
       type: (type_expression
         (identifier)))))
@@ -585,7 +585,7 @@ type
           (identifier)
           (colon_expression
             left: (identifier)
-            right: (string_literal
+            right: (interpreted_string_literal
               (string_content)))))
       (ref_type
         (object_declaration
@@ -609,7 +609,7 @@ type
                   (pragma_list
                     (colon_expression
                       left: (identifier)
-                      right: (string_literal
+                      right: (interpreted_string_literal
                         (string_content))))))
               type: (type_expression
                 (bracket_expression
@@ -976,7 +976,7 @@ proc trailing_fun(x, y,: float)
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content))))))
   (iterator_declaration
     name: (identifier)
@@ -1103,12 +1103,12 @@ type
         (enum_field_declaration
           (symbol_declaration
             name: (identifier))
-          value: (string_literal
+          value: (interpreted_string_literal
             (string_content)))
         (enum_field_declaration
           (symbol_declaration
             name: (identifier))
-          value: (string_literal
+          value: (interpreted_string_literal
             (string_content)))))
     (type_declaration
       (type_symbol_declaration
@@ -1123,7 +1123,7 @@ type
         (enum_field_declaration
           (symbol_declaration
             name: (identifier))
-          value: (string_literal
+          value: (interpreted_string_literal
             (string_content)))))
     (type_declaration
       (type_symbol_declaration

--- a/corpus/deviations.txt
+++ b/corpus/deviations.txt
@@ -14,14 +14,14 @@ r"string
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal
+  (interpreted_string_literal
     (string_content)
     (block_comment
       (comment_content)))
   (char_literal
     (block_comment
       (comment_content)))
-  (string_literal
+  (raw_string_literal
     (string_content)
     (block_comment
       (comment_content))))
@@ -41,16 +41,14 @@ a.b #[]#"c"
     (identifier)
     (block_comment
       (comment_content))
-    (string_literal
-      (string_content)))
+    (string_content))
   (generalized_string
     (dot_expression
       (identifier)
       (identifier))
     (block_comment
       (comment_content))
-    (string_literal
-      (string_content))))
+    (string_content)))
 
 ================================================================================
 Except deviations

--- a/corpus/deviations.txt
+++ b/corpus/deviations.txt
@@ -15,10 +15,12 @@ r"string
 
 (source_file
   (string_literal
+    (string_content)
     (block_comment))
   (char_literal
     (block_comment))
   (string_literal
+    (string_content)
     (block_comment)))
 
 ================================================================================
@@ -35,13 +37,15 @@ a.b #[]#"c"
   (generalized_string
     (identifier)
     (block_comment)
-    (string_literal))
+    (string_literal
+      (string_content)))
   (generalized_string
     (dot_expression
       (identifier)
       (identifier))
     (block_comment)
-    (string_literal)))
+    (string_literal
+      (string_content))))
 
 ================================================================================
 Except deviations

--- a/corpus/deviations.txt
+++ b/corpus/deviations.txt
@@ -16,12 +16,15 @@ r"string
 (source_file
   (string_literal
     (string_content)
-    (block_comment))
+    (block_comment
+      (comment_content)))
   (char_literal
-    (block_comment))
+    (block_comment
+      (comment_content)))
   (string_literal
     (string_content)
-    (block_comment)))
+    (block_comment
+      (comment_content))))
 
 ================================================================================
 Generalized string deviations
@@ -36,14 +39,16 @@ a.b #[]#"c"
 (source_file
   (generalized_string
     (identifier)
-    (block_comment)
+    (block_comment
+      (comment_content))
     (string_literal
       (string_content)))
   (generalized_string
     (dot_expression
       (identifier)
       (identifier))
-    (block_comment)
+    (block_comment
+      (comment_content))
     (string_literal
       (string_content))))
 

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -297,17 +297,16 @@ a(
       left: (identifier)
       right: (identifier)))
   (generalized_string
-    (dot_expression
+    function: (dot_expression
       left: (identifier)
       right: (identifier))
-    (string_literal
-      (string_content)))
+    (string_content))
   (call
     function: (dot_expression
       left: (identifier)
       right: (identifier))
     (argument_list
-      (string_literal
+      (interpreted_string_literal
         (string_content))))
   (dot_expression
     left: (call
@@ -443,14 +442,14 @@ collect(for x in s:
   (call
     function: (identifier)
     (argument_list
-      (string_literal
+      (interpreted_string_literal
         (string_content))
-      (string_literal
+      (interpreted_string_literal
         (string_content))))
   (call
     function: (identifier)
     (argument_list
-      (string_literal
+      (long_string_literal
         (string_content))))
   (call
     function: (identifier)
@@ -458,14 +457,14 @@ collect(for x in s:
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content))))
-      (string_literal
+      (interpreted_string_literal
         (string_content))
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content))))))
   (call
     function: (identifier)
@@ -644,7 +643,7 @@ foo {x}
         function: (identifier)
         (argument_list
           (integer_literal)))
-      (string_literal
+      (interpreted_string_literal
         (string_content))
       (call
         function: (identifier)
@@ -655,7 +654,7 @@ foo {x}
     (argument_list
       (identifier)
       (identifier)
-      (string_literal
+      (interpreted_string_literal
         (string_content))
       (call
         function: (identifier)
@@ -700,12 +699,12 @@ foo {x}
   (call
     function: (identifier)
     (argument_list
-      (string_literal
+      (interpreted_string_literal
         (string_content))))
   (call
     function: (identifier)
     (argument_list
-      (string_literal
+      (long_string_literal
         (string_content))))
   (call
     function: (identifier)
@@ -922,7 +921,7 @@ else: expr2
       (if
         condition: (identifier)
         consequence: (statement_list
-          (string_literal
+          (interpreted_string_literal
             (string_content)))
         alternative: (elif_branch
           condition: (identifier)
@@ -947,7 +946,7 @@ else: expr2
         alternative: (elif_branch
           condition: (identifier)
           consequence: (statement_list
-            (string_literal
+            (interpreted_string_literal
               (string_content))))
         alternative: (else_branch
           (statement_list
@@ -1034,7 +1033,7 @@ else: expr2
       (when
         condition: (identifier)
         consequence: (statement_list
-          (string_literal
+          (interpreted_string_literal
             (string_content)))
         alternative: (elif_branch
           condition: (identifier)
@@ -1062,7 +1061,7 @@ else: expr2
         alternative: (elif_branch
           condition: (identifier)
           consequence: (statement_list
-            (string_literal
+            (interpreted_string_literal
               (string_content))))
         alternative: (else_branch
           (statement_list
@@ -1172,7 +1171,7 @@ let x = case something(10)
         (call
           function: (identifier)
           (argument_list
-            (string_literal))))))
+            (interpreted_string_literal))))))
   (case
     value: (call
       function: (identifier)
@@ -1253,12 +1252,12 @@ except: echo y
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content))))
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content)))))
     (except_branch
       values: (expression_list
@@ -1273,12 +1272,12 @@ except: echo y
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content))))
       (call
         function: (identifier)
         (argument_list
-          (string_literal
+          (interpreted_string_literal
             (string_content)))))
     (except_branch
       values: (expression_list
@@ -1592,7 +1591,7 @@ Tuple construction
   (tuple_construction
     (colon_expression
       left: (identifier)
-      right: (string_literal
+      right: (interpreted_string_literal
         (string_content)))))
 
 ================================================================================
@@ -1609,7 +1608,7 @@ Parenthesized expressions
   (parenthesized
     (integer_literal))
   (parenthesized
-    (string_literal
+    (interpreted_string_literal
       (string_content)))
   (parenthesized
     (discard_statement)
@@ -1649,10 +1648,8 @@ foobar""""extra spicy""""
 
 (source_file
   (generalized_string
-    (identifier)
-    (string_literal
-      (string_content)))
+    function: (identifier)
+    (string_content))
   (generalized_string
-    (identifier)
-    (string_literal
-      (string_content))))
+    function: (identifier)
+    (string_content)))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -300,13 +300,15 @@ a(
     (dot_expression
       left: (identifier)
       right: (identifier))
-    (string_literal))
+    (string_literal
+      (string_content)))
   (call
     function: (dot_expression
       left: (identifier)
       right: (identifier))
     (argument_list
-      (string_literal)))
+      (string_literal
+        (string_content))))
   (dot_expression
     left: (call
       function: (identifier)
@@ -441,24 +443,30 @@ collect(for x in s:
   (call
     function: (identifier)
     (argument_list
-      (string_literal)
-      (string_literal)))
+      (string_literal
+        (string_content))
+      (string_literal
+        (string_content))))
   (call
     function: (identifier)
     (argument_list
-      (string_literal)))
+      (string_literal
+        (string_content))))
   (call
     function: (identifier)
     (argument_list
       (call
         function: (identifier)
         (argument_list
-          (string_literal)))
-      (string_literal)
+          (string_literal
+            (string_content))))
+      (string_literal
+        (string_content))
       (call
         function: (identifier)
         (argument_list
-          (string_literal)))))
+          (string_literal
+            (string_content))))))
   (call
     function: (identifier)
     (argument_list))
@@ -636,7 +644,8 @@ foo {x}
         function: (identifier)
         (argument_list
           (integer_literal)))
-      (string_literal)
+      (string_literal
+        (string_content))
       (call
         function: (identifier)
         (argument_list
@@ -646,7 +655,8 @@ foo {x}
     (argument_list
       (identifier)
       (identifier)
-      (string_literal)
+      (string_literal
+        (string_content))
       (call
         function: (identifier)
         (argument_list
@@ -690,11 +700,13 @@ foo {x}
   (call
     function: (identifier)
     (argument_list
-      (string_literal)))
+      (string_literal
+        (string_content))))
   (call
     function: (identifier)
     (argument_list
-      (string_literal)))
+      (string_literal
+        (string_content))))
   (call
     function: (identifier)
     (argument_list
@@ -910,7 +922,8 @@ else: expr2
       (if
         condition: (identifier)
         consequence: (statement_list
-          (string_literal))
+          (string_literal
+            (string_content)))
         alternative: (elif_branch
           condition: (identifier)
           consequence: (statement_list
@@ -934,7 +947,8 @@ else: expr2
         alternative: (elif_branch
           condition: (identifier)
           consequence: (statement_list
-            (string_literal)))
+            (string_literal
+              (string_content))))
         alternative: (else_branch
           (statement_list
             (integer_literal))))))
@@ -1020,7 +1034,8 @@ else: expr2
       (when
         condition: (identifier)
         consequence: (statement_list
-          (string_literal))
+          (string_literal
+            (string_content)))
         alternative: (elif_branch
           condition: (identifier)
           consequence: (statement_list
@@ -1047,7 +1062,8 @@ else: expr2
         alternative: (elif_branch
           condition: (identifier)
           consequence: (statement_list
-            (string_literal)))
+            (string_literal
+              (string_content))))
         alternative: (else_branch
           (statement_list
             (integer_literal))))))
@@ -1237,11 +1253,13 @@ except: echo y
       (call
         function: (identifier)
         (argument_list
-          (string_literal)))
+          (string_literal
+            (string_content))))
       (call
         function: (identifier)
         (argument_list
-          (string_literal))))
+          (string_literal
+            (string_content)))))
     (except_branch
       values: (expression_list
         (identifier))
@@ -1255,11 +1273,13 @@ except: echo y
       (call
         function: (identifier)
         (argument_list
-          (string_literal)))
+          (string_literal
+            (string_content))))
       (call
         function: (identifier)
         (argument_list
-          (string_literal))))
+          (string_literal
+            (string_content)))))
     (except_branch
       values: (expression_list
         (identifier))
@@ -1572,7 +1592,8 @@ Tuple construction
   (tuple_construction
     (colon_expression
       left: (identifier)
-      right: (string_literal))))
+      right: (string_literal
+        (string_content)))))
 
 ================================================================================
 Parenthesized expressions
@@ -1588,7 +1609,8 @@ Parenthesized expressions
   (parenthesized
     (integer_literal))
   (parenthesized
-    (string_literal))
+    (string_literal
+      (string_content)))
   (parenthesized
     (discard_statement)
     (integer_literal)))
@@ -1628,7 +1650,9 @@ foobar""""extra spicy""""
 (source_file
   (generalized_string
     (identifier)
-    (string_literal))
+    (string_literal
+      (string_content)))
   (generalized_string
     (identifier)
-    (string_literal)))
+    (string_literal
+      (string_content))))

--- a/corpus/extras.txt
+++ b/corpus/extras.txt
@@ -28,10 +28,13 @@ echo x,
 ##  this
 ##   that
 
+# #[]# should not induce a block comment
+
 --------------------------------------------------------------------------------
 
 (source_file
-  (comment)
+  (comment
+    (comment_content))
   (let_section
     (variable_declaration
       (symbol_declaration_list
@@ -40,9 +43,12 @@ echo x,
       (type_expression
         (identifier))
       (integer_literal))
-    (comment)
-    (comment)
-    (comment)
+    (comment
+      (comment_content))
+    (comment
+      (comment_content))
+    (comment
+      (comment_content))
     (variable_declaration
       (symbol_declaration_list
         (symbol_declaration
@@ -52,11 +58,17 @@ echo x,
     (identifier)
     (argument_list
       (identifier)
-      (comment)
+      (comment
+        (comment_content))
       (identifier)))
-  (documentation_comment)
-  (documentation_comment)
-  (documentation_comment))
+  (documentation_comment
+    (comment_content))
+  (documentation_comment
+    (comment_content))
+  (documentation_comment
+    (comment_content))
+  (comment
+    (comment_content)))
 
 ================================================================================
 Block comments
@@ -81,13 +93,18 @@ Block doc is not ##[self-nesting]#, though
 --------------------------------------------------------------------------------
 
 (source_file
-  (block_comment)
+  (block_comment
+    (comment_content))
   (call
     (identifier)
     (argument_list
       (identifier)
-      (block_comment)
+      (block_comment
+        (comment_content))
       (identifier)))
-  (block_comment)
-  (block_comment)
-  (block_documentation_comment))
+  (block_comment
+    (comment_content))
+  (block_comment
+    (comment_content))
+  (block_documentation_comment
+    (comment_content)))

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -152,54 +152,54 @@ r"C:\"
 --------------------------------------------------------------------------------
 
 (source_file
-  (string_literal)
-  (string_literal)
-  (string_literal
+  (interpreted_string_literal)
+  (raw_string_literal)
+  (interpreted_string_literal
     (string_content))
-  (string_literal
+  (interpreted_string_literal
     (string_content))
-  (string_literal
+  (interpreted_string_literal
     (string_content
       (escape_sequence)
       (escape_sequence)
       (escape_sequence)))
-  (string_literal
+  (interpreted_string_literal
     (string_content
       (escape_sequence)
       (escape_sequence)
       (escape_sequence)
       (escape_sequence)
       (escape_sequence)))
-  (string_literal
+  (raw_string_literal
     (string_content))
-  (string_literal
+  (raw_string_literal
     (string_content))
-  (string_literal
+  (raw_string_literal
     (string_content
       (escape_sequence)
       (escape_sequence)))
-  (string_literal
+  (raw_string_literal
     (string_content
       (escape_sequence)))
-  (string_literal
+  (raw_string_literal
     (string_content
       (escape_sequence)))
-  (string_literal)
-  (string_literal
+  (long_string_literal)
+  (long_string_literal
     (string_content))
-  (string_literal
+  (long_string_literal
     (string_content))
-  (string_literal
+  (long_string_literal
     (string_content))
   (block
     body: (statement_list
-      (string_literal
+      (long_string_literal
         (string_content))))
-  (string_literal
+  (interpreted_string_literal
     (string_content))
-  (string_literal
+  (long_string_literal
     (string_content))
-  (string_literal
+  (raw_string_literal
     (string_content)))
 
 ================================================================================

--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -154,37 +154,53 @@ r"C:\"
 (source_file
   (string_literal)
   (string_literal)
-  (string_literal)
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)))
+  (string_literal
+    (string_content
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)
+      (escape_sequence)))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content
+      (escape_sequence)
+      (escape_sequence)))
+  (string_literal
+    (string_content
+      (escape_sequence)))
+  (string_literal
+    (string_content
+      (escape_sequence)))
   (string_literal)
   (string_literal
-    (escape_sequence)
-    (escape_sequence)
-    (escape_sequence))
+    (string_content))
   (string_literal
-    (escape_sequence)
-    (escape_sequence)
-    (escape_sequence)
-    (escape_sequence)
-    (escape_sequence))
-  (string_literal)
-  (string_literal)
+    (string_content))
   (string_literal
-    (escape_sequence)
-    (escape_sequence))
-  (string_literal
-    (escape_sequence))
-  (string_literal
-    (escape_sequence))
-  (string_literal)
-  (string_literal)
-  (string_literal)
-  (string_literal)
+    (string_content))
   (block
     body: (statement_list
-      (string_literal)))
-  (string_literal)
-  (string_literal)
-  (string_literal))
+      (string_literal
+        (string_content))))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content))
+  (string_literal
+    (string_content)))
 
 ================================================================================
 Character literals

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -190,7 +190,7 @@ include X
   (include_statement
     (expression_list
       (identifier)
-      (string_literal
+      (interpreted_string_literal
         (string_content))))
   (include_statement
     (expression_list
@@ -214,7 +214,7 @@ discard foo as bar
 
 (source_file
   (discard_statement
-    (string_literal
+    (interpreted_string_literal
       (string_content)))
   (discard_statement)
   (discard_statement
@@ -245,10 +245,10 @@ asm "ret"
 
 (source_file
   (assembly_statement
-    (string_literal
+    (long_string_literal
       (string_content)))
   (assembly_statement
-    (string_literal
+    (interpreted_string_literal
       (string_content))))
 
 ================================================================================
@@ -412,7 +412,7 @@ static:
         function: (identifier)
         (argument_list
           (identifier)
-          (string_literal
+          (interpreted_string_literal
             (string_content)))))))
 
 ================================================================================
@@ -468,5 +468,5 @@ defer:
         (identifier)
         (argument_list
           (identifier)
-          (string_literal
+          (interpreted_string_literal
             (string_content)))))))

--- a/corpus/statements.txt
+++ b/corpus/statements.txt
@@ -190,7 +190,8 @@ include X
   (include_statement
     (expression_list
       (identifier)
-      (string_literal)))
+      (string_literal
+        (string_content))))
   (include_statement
     (expression_list
       (identifier))))
@@ -213,7 +214,8 @@ discard foo as bar
 
 (source_file
   (discard_statement
-    (string_literal))
+    (string_literal
+      (string_content)))
   (discard_statement)
   (discard_statement
     (identifier))
@@ -243,9 +245,11 @@ asm "ret"
 
 (source_file
   (assembly_statement
-    (string_literal))
+    (string_literal
+      (string_content)))
   (assembly_statement
-    (string_literal)))
+    (string_literal
+      (string_content))))
 
 ================================================================================
 Break statements
@@ -408,7 +412,8 @@ static:
         function: (identifier)
         (argument_list
           (identifier)
-          (string_literal))))))
+          (string_literal
+            (string_content)))))))
 
 ================================================================================
 Assignment
@@ -463,4 +468,5 @@ defer:
         (identifier)
         (argument_list
           (identifier)
-          (string_literal))))))
+          (string_literal
+            (string_content)))))))

--- a/grammar.js
+++ b/grammar.js
@@ -197,6 +197,7 @@ module.exports = grammar({
   externals: $ => [
     $._block_comment_content,
     $._block_documentation_comment_content,
+    $.comment_content, // used to notify the scanner
     $._long_string_quote,
     $._layout_start,
     $._layout_end,
@@ -1441,11 +1442,19 @@ module.exports = grammar({
     identifier: () => Identifier,
 
     block_documentation_comment: $ =>
-      seq(token(prec(1, "##[")), $._block_documentation_comment_content, "]##"),
+      seq(
+        token(prec(1, "##[")),
+        alias($._block_documentation_comment_content, $.comment_content),
+        "]##"
+      ),
     block_comment: $ =>
-      seq(token(prec(1, "#[")), $._block_comment_content, "]#"),
-    documentation_comment: () => /##[^\n\r]*/,
-    comment: () => /#[^\n\r]*/,
+      seq(
+        token(prec(1, "#[")),
+        alias($._block_comment_content, $.comment_content),
+        "]#"
+      ),
+    documentation_comment: $ => seq("##", $.comment_content),
+    comment: $ => seq("#", $.comment_content),
   },
 });
 

--- a/grammar.js
+++ b/grammar.js
@@ -451,7 +451,7 @@ module.exports = grammar({
       seq(
         keyword("asm"),
         optional(field("pragma", $.pragma_list)),
-        $.string_literal
+        $._string_literal
       ),
     bind_statement: $ => seq(keyword("bind"), $.expression_list),
     mixin_statement: $ => seq(keyword("mixin"), $.expression_list),
@@ -1226,8 +1226,8 @@ module.exports = grammar({
       choice(seq("(", optional($._colon_equal_expression_list), ")")),
     generalized_string: $ =>
       seq(
-        choice($.identifier, $.dot_expression),
-        alias($._generalized_string_literal, $.string_literal)
+        field("function", choice($.identifier, $.dot_expression)),
+        $._generalized_string_literal
       ),
     _generalized_string_literal: $ =>
       choice(
@@ -1344,7 +1344,7 @@ module.exports = grammar({
         $.float_literal,
         $.custom_numeric_literal,
         $.char_literal,
-        $.string_literal
+        $._string_literal
       ),
 
     nil_literal: () => keyword("nil"),
@@ -1377,14 +1377,14 @@ module.exports = grammar({
       ),
     _char_escape_sequence: () => token.immediate(seq("\\", CharEscapeSequence)),
 
-    string_literal: $ =>
+    _string_literal: $ =>
       choice(
-        $._interpreted_string_literal,
-        $._raw_string_literal,
-        $._long_string_literal
+        $.interpreted_string_literal,
+        $.raw_string_literal,
+        $.long_string_literal
       ),
 
-    _interpreted_string_literal: $ =>
+    interpreted_string_literal: $ =>
       seq(
         '"',
         optional(alias($._interpreted_string_body, $.string_content)),
@@ -1407,7 +1407,7 @@ module.exports = grammar({
         )
       ),
 
-    _raw_string_literal: $ =>
+    raw_string_literal: $ =>
       seq(
         choice('r"', 'R"'),
         optional(alias($._raw_string_body, $.string_content)),
@@ -1423,7 +1423,7 @@ module.exports = grammar({
       ),
     _raw_string_escape: () => token.immediate('""'),
 
-    _long_string_literal: $ =>
+    long_string_literal: $ =>
       seq(
         choice('"""', 'r"""', 'R"""'),
         optional(alias($._long_string_body, $.string_content)),

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -15,6 +15,12 @@
     (dot_expression
       right: (identifier) @function.call)
   ])
+(generalized_string
+  function: [
+    (identifier) @function.call
+    (dot_expression
+      right: (identifier) @function.call)
+  ])
 
 ; Declarations
 (exported_symbol "*" @type.qualifier)
@@ -73,7 +79,10 @@
   (block_documentation_comment)
 ] @comment.documentation
 
-(string_literal) @string
+(interpreted_string_literal) @string
+(long_string_literal) @string
+(raw_string_literal) @string
+(generalized_string) @string
 (char_literal) @character
 (escape_sequence) @string.escape
 (integer_literal) @number

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -10856,8 +10856,13 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "_block_documentation_comment_content"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_block_documentation_comment_content"
+          },
+          "named": true,
+          "value": "comment_content"
         },
         {
           "type": "STRING",
@@ -10880,8 +10885,13 @@
           }
         },
         {
-          "type": "SYMBOL",
-          "name": "_block_comment_content"
+          "type": "ALIAS",
+          "content": {
+            "type": "SYMBOL",
+            "name": "_block_comment_content"
+          },
+          "named": true,
+          "value": "comment_content"
         },
         {
           "type": "STRING",
@@ -10890,12 +10900,30 @@
       ]
     },
     "documentation_comment": {
-      "type": "PATTERN",
-      "value": "##[^\\n\\r]*"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "##"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comment_content"
+        }
+      ]
     },
     "comment": {
-      "type": "PATTERN",
-      "value": "#[^\\n\\r]*"
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "#"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "comment_content"
+        }
+      ]
     }
   },
   "extras": [
@@ -11264,6 +11292,10 @@
     {
       "type": "SYMBOL",
       "name": "_block_documentation_comment_content"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "comment_content"
     },
     {
       "type": "SYMBOL",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -9309,8 +9309,28 @@
               }
             },
             {
-              "type": "SYMBOL",
-              "name": "_long_string_body"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_long_string_body"
+                  },
+                  "named": true,
+                  "value": "string_content"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "\"\"\""
+              }
             }
           ]
         },
@@ -9325,8 +9345,28 @@
               }
             },
             {
-              "type": "SYMBOL",
-              "name": "_raw_string_body"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "ALIAS",
+                  "content": {
+                    "type": "SYMBOL",
+                    "name": "_raw_string_body"
+                  },
+                  "named": true,
+                  "value": "string_content"
+                },
+                {
+                  "type": "BLANK"
+                }
+              ]
+            },
+            {
+              "type": "IMMEDIATE_TOKEN",
+              "content": {
+                "type": "STRING",
+                "value": "\""
+              }
             }
           ]
         }
@@ -10524,27 +10564,21 @@
           "value": "\""
         },
         {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": 2,
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\\n\\r\"\\\\]+"
-                  }
-                }
-              },
-              {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "SYMBOL",
-                "name": "escape_sequence"
-              }
-            ]
-          }
+                "name": "_interpreted_string_body"
+              },
+              "named": true,
+              "value": "string_content"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "IMMEDIATE_TOKEN",
@@ -10554,6 +10588,29 @@
           }
         }
       ]
+    },
+    "_interpreted_string_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 2,
+              "content": {
+                "type": "PATTERN",
+                "value": "[^\\n\\r\"\\\\]+"
+              }
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "escape_sequence"
+          }
+        ]
+      }
     },
     "escape_sequence": {
       "type": "IMMEDIATE_TOKEN",
@@ -10601,41 +10658,21 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_raw_string_body"
-        }
-      ]
-    },
-    "_raw_string_body": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": 2,
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\\n\\r\"]"
-                  }
-                }
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_raw_string_body"
               },
-              {
-                "type": "ALIAS",
-                "content": {
-                  "type": "SYMBOL",
-                  "name": "_raw_string_escape"
-                },
-                "named": true,
-                "value": "escape_sequence"
-              }
-            ]
-          }
+              "named": true,
+              "value": "string_content"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "IMMEDIATE_TOKEN",
@@ -10645,6 +10682,34 @@
           }
         }
       ]
+    },
+    "_raw_string_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 2,
+              "content": {
+                "type": "PATTERN",
+                "value": "[^\\n\\r\"]"
+              }
+            }
+          },
+          {
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_raw_string_escape"
+            },
+            "named": true,
+            "value": "escape_sequence"
+          }
+        ]
+      }
     },
     "_raw_string_escape": {
       "type": "IMMEDIATE_TOKEN",
@@ -10674,36 +10739,21 @@
           ]
         },
         {
-          "type": "SYMBOL",
-          "name": "_long_string_body"
-        }
-      ]
-    },
-    "_long_string_body": {
-      "type": "SEQ",
-      "members": [
-        {
-          "type": "REPEAT",
-          "content": {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "IMMEDIATE_TOKEN",
-                "content": {
-                  "type": "PREC",
-                  "value": 2,
-                  "content": {
-                    "type": "PATTERN",
-                    "value": "[^\"]+"
-                  }
-                }
-              },
-              {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "ALIAS",
+              "content": {
                 "type": "SYMBOL",
-                "name": "_long_string_quote"
-              }
-            ]
-          }
+                "name": "_long_string_body"
+              },
+              "named": true,
+              "value": "string_content"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         },
         {
           "type": "IMMEDIATE_TOKEN",
@@ -10713,6 +10763,29 @@
           }
         }
       ]
+    },
+    "_long_string_body": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "IMMEDIATE_TOKEN",
+            "content": {
+              "type": "PREC",
+              "value": 2,
+              "content": {
+                "type": "PATTERN",
+                "value": "[^\"]+"
+              }
+            }
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_long_string_quote"
+          }
+        ]
+      }
     },
     "_symbol": {
       "type": "CHOICE",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -651,7 +651,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "string_literal"
+          "name": "_string_literal"
         }
       ]
     },
@@ -9272,26 +9272,25 @@
       "type": "SEQ",
       "members": [
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "SYMBOL",
-              "name": "identifier"
-            },
-            {
-              "type": "SYMBOL",
-              "name": "dot_expression"
-            }
-          ]
+          "type": "FIELD",
+          "name": "function",
+          "content": {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "identifier"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "dot_expression"
+              }
+            ]
+          }
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_generalized_string_literal"
-          },
-          "named": true,
-          "value": "string_literal"
+          "type": "SYMBOL",
+          "name": "_generalized_string_literal"
         }
       ]
     },
@@ -10096,7 +10095,7 @@
         },
         {
           "type": "SYMBOL",
-          "name": "string_literal"
+          "name": "_string_literal"
         }
       ]
     },
@@ -10539,24 +10538,24 @@
         ]
       }
     },
-    "string_literal": {
+    "_string_literal": {
       "type": "CHOICE",
       "members": [
         {
           "type": "SYMBOL",
-          "name": "_interpreted_string_literal"
+          "name": "interpreted_string_literal"
         },
         {
           "type": "SYMBOL",
-          "name": "_raw_string_literal"
+          "name": "raw_string_literal"
         },
         {
           "type": "SYMBOL",
-          "name": "_long_string_literal"
+          "name": "long_string_literal"
         }
       ]
     },
-    "_interpreted_string_literal": {
+    "interpreted_string_literal": {
       "type": "SEQ",
       "members": [
         {
@@ -10641,7 +10640,7 @@
         ]
       }
     },
-    "_raw_string_literal": {
+    "raw_string_literal": {
       "type": "SEQ",
       "members": [
         {
@@ -10718,7 +10717,7 @@
         "value": "\"\""
       }
     },
-    "_long_string_literal": {
+    "long_string_literal": {
       "type": "SEQ",
       "members": [
         {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -9650,7 +9650,7 @@
     }
   },
   {
-    "type": "string_literal",
+    "type": "string_content",
     "named": true,
     "fields": {},
     "children": {
@@ -9659,6 +9659,21 @@
       "types": [
         {
           "type": "escape_sequence",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "string_content",
           "named": true
         }
       ]

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -812,12 +812,32 @@
   {
     "type": "block_comment",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "comment_content",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "block_documentation_comment",
     "named": true,
-    "fields": {}
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "comment_content",
+          "named": true
+        }
+      ]
+    }
   },
   {
     "type": "bracket_expression",
@@ -2184,6 +2204,21 @@
     }
   },
   {
+    "type": "comment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "comment_content",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
     "type": "concept_declaration",
     "named": true,
     "fields": {
@@ -3340,6 +3375,21 @@
           }
         ]
       }
+    }
+  },
+  {
+    "type": "documentation_comment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "comment_content",
+          "named": true
+        }
+      ]
     }
   },
   {
@@ -11719,6 +11769,14 @@
     "named": false
   },
   {
+    "type": "#",
+    "named": false
+  },
+  {
+    "type": "##",
+    "named": false
+  },
+  {
     "type": "##[",
     "named": false
   },
@@ -11839,7 +11897,7 @@
     "named": false
   },
   {
-    "type": "comment",
+    "type": "comment_content",
     "named": true
   },
   {
@@ -11881,10 +11939,6 @@
   {
     "type": "do",
     "named": false
-  },
-  {
-    "type": "documentation_comment",
-    "named": true
   },
   {
     "type": "elif",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -147,11 +147,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -195,15 +203,15 @@
           "named": true
         },
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "ref_type",
           "named": true
         },
         {
           "type": "statement_list",
-          "named": true
-        },
-        {
-          "type": "string_literal",
           "named": true
         },
         {
@@ -342,11 +350,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -386,11 +402,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -436,7 +452,15 @@
       "required": true,
       "types": [
         {
-          "type": "string_literal",
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
+          "named": true
+        },
+        {
+          "type": "raw_string_literal",
           "named": true
         }
       ]
@@ -527,7 +551,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -563,11 +595,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -685,11 +717,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -729,11 +769,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -920,7 +960,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -956,11 +1004,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -1094,11 +1142,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -1138,11 +1194,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -1249,7 +1305,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -1285,11 +1349,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -1383,7 +1447,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -1419,11 +1491,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -1567,11 +1639,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -1611,11 +1691,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -1795,11 +1875,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -1839,11 +1927,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -1970,7 +2058,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -2006,11 +2102,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -2128,11 +2224,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -2172,11 +2276,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -2373,11 +2477,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -2417,11 +2529,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -2578,11 +2690,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -2622,11 +2742,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -2861,11 +2981,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -2905,11 +3033,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -3016,7 +3144,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -3052,11 +3188,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -3206,11 +3342,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -3250,11 +3394,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -3473,7 +3617,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -3509,11 +3661,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -3631,7 +3783,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -3667,11 +3827,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -3833,11 +3993,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -3877,11 +4045,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -4061,11 +4229,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -4105,11 +4281,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -4236,7 +4412,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -4272,11 +4456,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -4394,11 +4578,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -4438,11 +4630,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -4623,11 +4815,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -4667,11 +4867,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -4825,11 +5025,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -4869,11 +5077,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -5022,11 +5230,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -5066,11 +5282,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -5278,11 +5494,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -5322,11 +5546,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -5502,21 +5726,28 @@
   {
     "type": "generalized_string",
     "named": true,
-    "fields": {},
+    "fields": {
+      "function": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "dot_expression",
+            "named": true
+          },
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
-      "required": true,
+      "multiple": false,
+      "required": false,
       "types": [
         {
-          "type": "dot_expression",
-          "named": true
-        },
-        {
-          "type": "identifier",
-          "named": true
-        },
-        {
-          "type": "string_literal",
+          "type": "string_content",
           "named": true
         }
       ]
@@ -5627,11 +5858,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -5671,11 +5910,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -5835,11 +6074,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -5879,11 +6126,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -6025,11 +6272,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -6069,11 +6324,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -6223,11 +6478,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -6267,11 +6530,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -6397,7 +6660,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -6433,11 +6704,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -6601,7 +6872,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -6637,11 +6916,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -6689,6 +6968,21 @@
         },
         {
           "type": "statement_list",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "interpreted_string_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -6890,6 +7184,21 @@
       "types": [
         {
           "type": "variable_declaration",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "long_string_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -7316,11 +7625,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -7360,11 +7677,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -7620,6 +7937,10 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_declaration",
           "named": true
         },
@@ -7633,6 +7954,10 @@
         },
         {
           "type": "let_section",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -7696,6 +8021,10 @@
           "named": true
         },
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "ref_type",
           "named": true
         },
@@ -7705,10 +8034,6 @@
         },
         {
           "type": "static_statement",
-          "named": true
-        },
-        {
-          "type": "string_literal",
           "named": true
         },
         {
@@ -7909,7 +8234,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -7945,11 +8278,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -8091,11 +8424,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -8135,11 +8476,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -8367,7 +8708,15 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -8407,15 +8756,15 @@
           "named": true
         },
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "ref_type",
           "named": true
         },
         {
           "type": "statement_list",
-          "named": true
-        },
-        {
-          "type": "string_literal",
           "named": true
         },
         {
@@ -8724,11 +9073,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -8768,11 +9125,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -8793,6 +9150,21 @@
         },
         {
           "type": "when",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "raw_string_literal",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": false,
+      "types": [
+        {
+          "type": "string_content",
           "named": true
         }
       ]
@@ -8988,11 +9360,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -9032,11 +9412,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -9223,6 +9603,10 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_declaration",
           "named": true
         },
@@ -9236,6 +9620,10 @@
         },
         {
           "type": "let_section",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -9299,6 +9687,10 @@
           "named": true
         },
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "ref_type",
           "named": true
         },
@@ -9308,10 +9700,6 @@
         },
         {
           "type": "static_statement",
-          "named": true
-        },
-        {
-          "type": "string_literal",
           "named": true
         },
         {
@@ -9522,6 +9910,10 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_declaration",
           "named": true
         },
@@ -9535,6 +9927,10 @@
         },
         {
           "type": "let_section",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -9598,6 +9994,10 @@
           "named": true
         },
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "ref_type",
           "named": true
         },
@@ -9607,10 +10007,6 @@
         },
         {
           "type": "static_statement",
-          "named": true
-        },
-        {
-          "type": "string_literal",
           "named": true
         },
         {
@@ -9709,21 +10105,6 @@
       "types": [
         {
           "type": "escape_sequence",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "string_literal",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "string_content",
           "named": true
         }
       ]
@@ -10043,6 +10424,10 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_declaration",
           "named": true
         },
@@ -10056,6 +10441,10 @@
         },
         {
           "type": "let_section",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -10119,6 +10508,10 @@
           "named": true
         },
         {
+          "type": "raw_string_literal",
+          "named": true
+        },
+        {
           "type": "ref_type",
           "named": true
         },
@@ -10128,10 +10521,6 @@
         },
         {
           "type": "static_statement",
-          "named": true
-        },
-        {
-          "type": "string_literal",
           "named": true
         },
         {
@@ -10324,11 +10713,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -10368,11 +10765,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -10572,7 +10969,15 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -10608,11 +11013,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {
@@ -10907,11 +11312,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -10951,11 +11364,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -11138,11 +11551,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -11182,11 +11603,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -11342,11 +11763,19 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_expression",
             "named": true
           },
           {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -11386,11 +11815,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -11522,7 +11951,15 @@
             "named": true
           },
           {
+            "type": "interpreted_string_literal",
+            "named": true
+          },
+          {
             "type": "iterator_type",
+            "named": true
+          },
+          {
+            "type": "long_string_literal",
             "named": true
           },
           {
@@ -11558,11 +11995,11 @@
             "named": true
           },
           {
-            "type": "ref_type",
+            "type": "raw_string_literal",
             "named": true
           },
           {
-            "type": "string_literal",
+            "type": "ref_type",
             "named": true
           },
           {
@@ -11686,11 +12123,19 @@
           "named": true
         },
         {
+          "type": "interpreted_string_literal",
+          "named": true
+        },
+        {
           "type": "iterator_expression",
           "named": true
         },
         {
           "type": "iterator_type",
+          "named": true
+        },
+        {
+          "type": "long_string_literal",
           "named": true
         },
         {
@@ -11730,11 +12175,11 @@
           "named": true
         },
         {
-          "type": "ref_type",
+          "type": "raw_string_literal",
           "named": true
         },
         {
-          "type": "string_literal",
+          "type": "ref_type",
           "named": true
         },
         {

--- a/test/highlight/expressions.nim
+++ b/test/highlight/expressions.nim
@@ -5,3 +5,7 @@
 # <- number
 #  ^ operator
 #    ^ number
+
+foo"string"
+# <- function.call
+#  ^ string

--- a/test/highlight/expressions.nim
+++ b/test/highlight/expressions.nim
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2023 Leorize <leorize+oss@disroot.org>
 # SPDX-License-Identifier: MPL-2.0
 
-1 + 1
+10 + 1
 # <- number
-# ^ operator
-#   ^ number
+#  ^ operator
+#    ^ number


### PR DESCRIPTION
Contents of string and comment types are now spun out of the main node. This should make it easier to query against by avoiding offset dances.

As an aside, the string literal type is also specialized into different variants, as a consistency change to align with what was done for comment types.