### PR TITLE
make (), [], {} and {.} inhibit layout end

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -426,6 +426,10 @@ test(
 collect(for x in s:
   {s: x})
 
+block:
+  foo(a, b,
+"string")
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -591,7 +595,16 @@ collect(for x in s:
           (curly_construction
             (colon_expression
               left: (identifier)
-              right: (identifier))))))))
+              right: (identifier)))))))
+  (block
+    body: (statement_list
+      (call
+        function: (identifier)
+        (argument_list
+          (identifier)
+          (identifier)
+          (interpreted_string_literal
+            (string_content)))))))
 
 ================================================================================
 Command calls
@@ -1491,6 +1504,10 @@ y, z, 10,
 [c: if c:
   d]
 
+block:
+  [a, b,
+c, d]
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1521,7 +1538,14 @@ y, z, 10,
       (if
         (identifier)
         (statement_list
-          (identifier))))))
+          (identifier)))))
+  (block
+    (statement_list
+      (array_construction
+        (identifier)
+        (identifier)
+        (identifier)
+        (identifier)))))
 
 ================================================================================
 Set/Table construction
@@ -1536,6 +1560,10 @@ Set/Table construction
 
 {a: when c:
   d}
+
+block:
+  {a, b,
+c, d}
 
 --------------------------------------------------------------------------------
 
@@ -1560,7 +1588,14 @@ Set/Table construction
       (when
         (identifier)
         (statement_list
-          (identifier))))))
+          (identifier)))))
+  (block
+    (statement_list
+      (curly_construction
+        (identifier)
+        (identifier)
+        (identifier)
+        (identifier)))))
 
 ================================================================================
 Tuple construction
@@ -1571,6 +1606,10 @@ Tuple construction
 (20,)
 (x: 1, 2,)
 (a: "string")
+
+block:
+  (a: "string",
+b: 42)
 
 --------------------------------------------------------------------------------
 
@@ -1592,7 +1631,17 @@ Tuple construction
     (colon_expression
       left: (identifier)
       right: (interpreted_string_literal
-        (string_content)))))
+        (string_content))))
+  (block
+    body: (statement_list
+      (tuple_construction
+        (colon_expression
+          left: (identifier)
+          right: (interpreted_string_literal
+            (string_content)))
+        (colon_expression
+          left: (identifier)
+          right: (integer_literal))))))
 
 ================================================================================
 Parenthesized expressions
@@ -1601,6 +1650,10 @@ Parenthesized expressions
 (10)
 ("string")
 (discard; 1;)
+
+block:
+  ("may extend outside of indent",
+expr)
 
 --------------------------------------------------------------------------------
 
@@ -1612,7 +1665,13 @@ Parenthesized expressions
       (string_content)))
   (parenthesized
     (discard_statement)
-    (integer_literal)))
+    (integer_literal))
+  (block
+    (statement_list
+      (tuple_construction
+        (interpreted_string_literal
+          (string_content))
+        (identifier)))))
 
 ================================================================================
 Cast expressions

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1280,8 +1280,8 @@
           "name": "_parameter_declaration_list"
         },
         {
-          "type": "STRING",
-          "value": "]"
+          "type": "SYMBOL",
+          "name": "_bracket_close"
         }
       ]
     },
@@ -1297,8 +1297,8 @@
           "name": "_statement"
         },
         {
-          "type": "STRING",
-          "value": "}"
+          "type": "SYMBOL",
+          "name": "_curly_close"
         }
       ]
     },
@@ -4039,8 +4039,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": ")"
+          "type": "SYMBOL",
+          "name": "_paren_close"
         }
       ]
     },
@@ -4209,8 +4209,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "]"
+          "type": "SYMBOL",
+          "name": "_bracket_close"
         }
       ]
     },
@@ -4653,8 +4653,8 @@
           "name": "_field_declaration_list"
         },
         {
-          "type": "STRING",
-          "value": "]"
+          "type": "SYMBOL",
+          "name": "_bracket_close"
         }
       ]
     },
@@ -8842,8 +8842,8 @@
                     "name": "type_expression"
                   },
                   {
-                    "type": "STRING",
-                    "value": "]"
+                    "type": "SYMBOL",
+                    "name": "_bracket_close"
                   }
                 ]
               },
@@ -8877,8 +8877,8 @@
                 ]
               },
               {
-                "type": "STRING",
-                "value": ")"
+                "type": "SYMBOL",
+                "name": "_paren_close"
               }
             ]
           }
@@ -8957,8 +8957,8 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": ")"
+              "type": "SYMBOL",
+              "name": "_paren_close"
             }
           ]
         },
@@ -9011,8 +9011,8 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": ")"
+              "type": "SYMBOL",
+              "name": "_paren_close"
             }
           ]
         }
@@ -9090,8 +9090,8 @@
             }
           },
           {
-            "type": "STRING",
-            "value": "]"
+            "type": "SYMBOL",
+            "name": "_bracket_close"
           }
         ]
       }
@@ -9139,8 +9139,8 @@
             }
           },
           {
-            "type": "STRING",
-            "value": "}"
+            "type": "SYMBOL",
+            "name": "_curly_close"
           }
         ]
       }
@@ -9186,8 +9186,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": "]"
+          "type": "SYMBOL",
+          "name": "_bracket_close"
         }
       ]
     },
@@ -9206,8 +9206,8 @@
               "name": "_colon_equal_expression_list"
             },
             {
-              "type": "STRING",
-              "value": "}"
+              "type": "SYMBOL",
+              "name": "_curly_close"
             }
           ]
         },
@@ -9231,8 +9231,8 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": "}"
+              "type": "SYMBOL",
+              "name": "_curly_close"
             }
           ]
         }
@@ -9261,8 +9261,8 @@
               ]
             },
             {
-              "type": "STRING",
-              "value": ")"
+              "type": "SYMBOL",
+              "name": "_paren_close"
             }
           ]
         }
@@ -9394,12 +9394,12 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "STRING",
-              "value": ".}"
+              "type": "SYMBOL",
+              "name": "_dot_curly_close"
             },
             {
-              "type": "STRING",
-              "value": "}"
+              "type": "SYMBOL",
+              "name": "_curly_close"
             }
           ]
         }
@@ -9674,8 +9674,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": ")"
+          "type": "SYMBOL",
+          "name": "_paren_close"
         }
       ]
     },
@@ -10009,8 +10009,8 @@
           ]
         },
         {
-          "type": "STRING",
-          "value": ")"
+          "type": "SYMBOL",
+          "name": "_paren_close"
         }
       ]
     },
@@ -10840,6 +10840,90 @@
       "type": "PATTERN",
       "value": "[a-zA-Z\\x80-\\xff](_?[a-zA-Z0-9\\x80-\\xff])*"
     },
+    "_paren_close": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_inhibit_layout_end"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "_bracket_close": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_inhibit_layout_end"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "_curly_close": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_inhibit_layout_end"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "}"
+        }
+      ]
+    },
+    "_dot_curly_close": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_inhibit_layout_end"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ".}"
+        }
+      ]
+    },
     "block_documentation_comment": {
       "type": "SEQ",
       "members": [
@@ -11315,6 +11399,10 @@
     {
       "type": "SYMBOL",
       "name": "_layout_empty"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_inhibit_layout_end"
     },
     {
       "type": "STRING",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -218,6 +218,7 @@ enum token_type {
   LAYOUT_END,
   LAYOUT_TERMINATOR,
   LAYOUT_EMPTY,
+  INHIBIT_LAYOUT_END,
   COMMA,
   SYNCHRONIZE,
   INVALID_LAYOUT,
@@ -238,6 +239,7 @@ const char* const TOKEN_TYPE_STR[TOKEN_TYPE_LEN] = {
     "LAYOUT_END",
     "LAYOUT_TERMINATOR",
     "LAYOUT_EMPTY",
+    "INHIBIT_LAYOUT_END",
     "COMMA",
     "SYNCHRONIZE",
     "INVALID_LAYOUT",
@@ -727,6 +729,9 @@ LEX_FN(lex_case_of)
   }
 }
 
+const struct valid_tokens NO_LAYOUT_END_CTX =
+    VALID_TOKENS(TO_VT_BIT(INHIBIT_LAYOUT_END) | TO_VT_BIT(LONG_STRING_QUOTE));
+
 // This function is big by design.
 //
 // NOLINTNEXTLINE(*-cognitive-complexity)
@@ -803,7 +808,7 @@ LEX_FN(lex_indent)
   }
 
   // Implicit layout changes
-  if (!valid_tokens_test(ctx->valid_tokens, LONG_STRING_QUOTE) ||
+  if (!valid_tokens_any_valid(ctx->valid_tokens, NO_LAYOUT_END_CTX) ||
       valid_tokens_is_error(ctx->valid_tokens)) {
     // LAYOUT_END
     if (current_indent < current_layout || context_eof(ctx)) {


### PR DESCRIPTION
In Nim these contexts are allowed to have indentation below that of the current layout.

Fixes 9cda851ed098e3f0a501e2c676ca26dc6a1a8884