### PR TITLE
add a test for hanging dot expression

### DIFF
--- a/corpus/errors.txt
+++ b/corpus/errors.txt
@@ -57,3 +57,23 @@ if true:
             (except_branch
               (statement_list
                 (ERROR)))))))))
+
+================================================================================
+Hanging dot error
+================================================================================
+
+func main() =
+  f.
+
+a
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (func_declaration
+    (identifier)
+    (parameter_declaration_list)
+    (statement_list
+      (ERROR
+        (identifier))))
+  (identifier))


### PR DESCRIPTION
It was discovered that prior to 9cda851ed098e3f0a501e2c676ca26dc6a1a8884 the parser accepted this code.