### PR TITLE
implement termination rule for if/try

### DIFF
--- a/corpus/errors.txt
+++ b/corpus/errors.txt
@@ -77,3 +77,21 @@ a
       (ERROR
         (identifier))))
   (identifier))
+
+================================================================================
+Continuing keyword at wrong places
+================================================================================
+
+let a = 5
+finally
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (let_section
+    (variable_declaration
+      (symbol_declaration_list
+        (symbol_declaration
+          (identifier)))
+      (integer_literal)))
+  (identifier))

--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -911,6 +911,13 @@ block:
 if true: expr1
 else: expr2
 
+if true:
+  foo else: bar
+
+if true:
+  proc foo =
+    discard else: bar
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -982,6 +989,23 @@ else: expr2
     condition: (identifier)
     consequence: (statement_list
       (identifier))
+    alternative: (else_branch
+      (statement_list
+        (identifier))))
+  (if
+    condition: (identifier)
+    consequence: (statement_list
+      (identifier))
+    alternative: (else_branch
+      (statement_list
+        (identifier))))
+  (if
+    condition: (identifier)
+    consequence: (statement_list
+      (proc_declaration
+        name: (identifier)
+        body: (statement_list
+          (discard_statement))))
     alternative: (else_branch
       (statement_list
         (identifier)))))
@@ -1257,6 +1281,10 @@ finally:
 try: echo x
 except: echo y
 
+try:
+  echo x except: echo y
+finally: bar
+
 --------------------------------------------------------------------------------
 
 (source_file
@@ -1326,7 +1354,22 @@ except: echo y
         (call
           function: (identifier)
           (argument_list
-            (identifier)))))))
+            (identifier))))))
+  (try
+    body: (statement_list
+      (call
+        function: (identifier)
+        (argument_list
+          (identifier))))
+    (except_branch
+      (statement_list
+        (call
+          function: (identifier)
+          (argument_list
+            (identifier)))))
+    (finally_branch
+      (statement_list
+        (identifier)))))
 
 ================================================================================
 Pragma statements

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -337,6 +337,18 @@
           "name": "_expression"
         },
         {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_inhibit_keyword_termination"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
           "type": "SYMBOL",
           "name": "except_clause"
         }
@@ -2241,6 +2253,10 @@
                     },
                     "named": true,
                     "value": "else_branch"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_inhibit_keyword_termination"
                   }
                 ]
               }
@@ -2353,6 +2369,18 @@
               "named": true,
               "value": "of_branch"
             }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_inhibit_keyword_termination"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -3286,8 +3314,17 @@
             "content": {
               "type": "REPEAT",
               "content": {
-                "type": "SYMBOL",
-                "name": "_if_branch"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_inhibit_keyword_termination"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "_if_branch"
+                  }
+                ]
               }
             }
           }
@@ -3368,9 +3405,38 @@
           {
             "type": "REPEAT",
             "content": {
-              "type": "SYMBOL",
-              "name": "elif_branch"
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "_inhibit_keyword_termination"
+                    },
+                    {
+                      "type": "BLANK"
+                    }
+                  ]
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "elif_branch"
+                }
+              ]
             }
+          },
+          {
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "SYMBOL",
+                "name": "_inhibit_keyword_termination"
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "CHOICE",
@@ -3430,8 +3496,17 @@
       "content": {
         "type": "REPEAT1",
         "content": {
-          "type": "SYMBOL",
-          "name": "_try_branch"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_inhibit_keyword_termination"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "_try_branch"
+            }
+          ]
         }
       }
     },
@@ -4280,6 +4355,10 @@
               {
                 "type": "SYMBOL",
                 "name": "do_block"
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_inhibit_keyword_termination"
               }
             ]
           }
@@ -11403,6 +11482,10 @@
     {
       "type": "SYMBOL",
       "name": "_inhibit_layout_end"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_inhibit_keyword_termination"
     },
     {
       "type": "STRING",


### PR DESCRIPTION
Within an if/try context, any keyword like else or except can be used to terminate any inner blocks.

This commit also allows the parser to properly terminate statements when a continuing keyword shows up at the wrong places.

Fixes https://github.com/alaviss/tree-sitter-nim/issues/41