### PR TITLE
scanner: allow end on EOF and use column for flag invalidation

### DIFF
--- a/corpus/errors.txt
+++ b/corpus/errors.txt
@@ -22,8 +22,7 @@ type
                 (symbol_declaration
                   (identifier)))))
           (ERROR
-            (identifier)))))
-    (MISSING _layout_end)))
+            (identifier)))))))
 
 ================================================================================
 Error within statements with body
@@ -113,3 +112,22 @@ if x:
       (try
         (statement_list
           (discard_statement))))))
+
+================================================================================
+Incomplete let statement with unclosed parenthesis
+================================================================================
+
+let
+  x: int = (
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (let_section
+    (variable_declaration
+      (symbol_declaration_list
+        (symbol_declaration
+          (identifier)))
+      (type_expression
+        (identifier)))
+    (ERROR)))


### PR DESCRIPTION
Allowing layout_end on EOF allows the parser to close and isolate grammar portions where layout_end is typically not allowed (ie. in parentheses), which enabled better error recovery.

The empty termination hack does not seem to contribute anymore with this change and was removed.

With this change, we also remove the use of synchronize node for fixing after newline. Instead it is cleared based on column position at the start of the lexer. This should reduce errors from node reuse, but is more or less a hunch since it is hard to test incremental parsing.

Fixes https://github.com/alaviss/tree-sitter-nim/issues/64.