### PR TITLE
make type declaration RHS optional

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -1214,3 +1214,31 @@ type
             alternative: (else_branch
               consequence: (statement_list
                 (identifier)))))))))
+
+================================================================================
+Empty type declarations
+================================================================================
+
+type
+  X
+  Y
+  Z {.magic: "Int".}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (type_section
+    (type_declaration
+      (type_symbol_declaration
+        (identifier)))
+    (type_declaration
+      (type_symbol_declaration
+        (identifier)))
+    (type_declaration
+      (type_symbol_declaration
+        (identifier)
+        (pragma_list
+          (colon_expression
+            (identifier)
+            (interpreted_string_literal
+              (string_content))))))))

--- a/grammar.js
+++ b/grammar.js
@@ -544,7 +544,7 @@ module.exports = grammar({
 
     type_section: $ => seq(keyword("type"), section($, $.type_declaration)),
     type_declaration: $ =>
-      seq($.type_symbol_declaration, "=", $._type_definition),
+      seq($.type_symbol_declaration, optional(seq("=", $._type_definition))),
     type_symbol_declaration: $ =>
       seq(
         field("name", choice($._symbol, $.exported_symbol)),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1626,12 +1626,25 @@
           "name": "type_symbol_declaration"
         },
         {
-          "type": "STRING",
-          "value": "="
-        },
-        {
-          "type": "SYMBOL",
-          "name": "_type_definition"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "STRING",
+                  "value": "="
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "_type_definition"
+                }
+              ]
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
This syntax quirk is utilized by `system.nim`

Fixes https://github.com/alaviss/tree-sitter-nim/issues/66.