### PR TITLE
add missing consequence field to object declaration

### DIFF
--- a/corpus/declarations.txt
+++ b/corpus/declarations.txt
@@ -470,14 +470,14 @@ type
             (of_branch
               values: (expression_list
                 (identifier))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (discard_statement)))
             (of_branch
               values: (expression_list
                 (identifier)
                 (identifier)
                 (identifier))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (nil_literal)))
             (of_branch
               values: (expression_list
@@ -485,7 +485,7 @@ type
                   left: (identifier)
                   operator: (operator)
                   right: (identifier)))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (field_declaration
                   (symbol_declaration_list
                     (symbol_declaration
@@ -498,7 +498,7 @@ type
                   left: (identifier)
                   operator: (operator)
                   right: (identifier)))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (field_declaration
                   (symbol_declaration_list
                     (symbol_declaration
@@ -514,7 +514,7 @@ type
                 (identifier)
                 (identifier)
                 (identifier))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (field_declaration
                   (symbol_declaration_list
                     (symbol_declaration
@@ -522,7 +522,7 @@ type
                   type: (type_expression
                     (identifier)))))
             (else_branch
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (field_declaration
                   (symbol_declaration_list
                     (symbol_declaration
@@ -547,7 +547,7 @@ type
             (of_branch
               values: (expression_list
                 (identifier))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (nil_literal))))))))
   (type_section
     (type_declaration
@@ -667,7 +667,7 @@ type
             (of_branch
               values: (expression_list
                 (identifier))
-              (field_declaration_list
+              consequence: (field_declaration_list
                 (field_declaration
                   (symbol_declaration_list
                     (symbol_declaration

--- a/grammar.js
+++ b/grammar.js
@@ -682,13 +682,25 @@ module.exports = grammar({
         alias($._case_of, "of"),
         field("values", $.expression_list),
         ":",
-        alias($._object_field_declaration_branch_list, $.field_declaration_list)
+        field(
+          "consequence",
+          alias(
+            $._object_field_declaration_branch_list,
+            $.field_declaration_list
+          )
+        )
       ),
     _else_declaration_branch: $ =>
       seq(
         keyword("else"),
         ":",
-        alias($._object_field_declaration_branch_list, $.field_declaration_list)
+        field(
+          "consequence",
+          alias(
+            $._object_field_declaration_branch_list,
+            $.field_declaration_list
+          )
+        )
       ),
 
     concept_declaration: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2465,13 +2465,17 @@
           "value": ":"
         },
         {
-          "type": "ALIAS",
+          "type": "FIELD",
+          "name": "consequence",
           "content": {
-            "type": "SYMBOL",
-            "name": "_object_field_declaration_branch_list"
-          },
-          "named": true,
-          "value": "field_declaration_list"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_object_field_declaration_branch_list"
+            },
+            "named": true,
+            "value": "field_declaration_list"
+          }
         }
       ]
     },
@@ -2499,13 +2503,17 @@
           "value": ":"
         },
         {
-          "type": "ALIAS",
+          "type": "FIELD",
+          "name": "consequence",
           "content": {
-            "type": "SYMBOL",
-            "name": "_object_field_declaration_branch_list"
-          },
-          "named": true,
-          "value": "field_declaration_list"
+            "type": "ALIAS",
+            "content": {
+              "type": "SYMBOL",
+              "name": "_object_field_declaration_branch_list"
+            },
+            "named": true,
+            "value": "field_declaration_list"
+          }
         }
       ]
     },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -4068,24 +4068,18 @@
     "fields": {
       "consequence": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
+          {
+            "type": "field_declaration_list",
+            "named": true
+          },
           {
             "type": "statement_list",
             "named": true
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "field_declaration_list",
-          "named": true
-        }
-      ]
     }
   },
   {
@@ -7391,8 +7385,12 @@
     "fields": {
       "consequence": {
         "multiple": false,
-        "required": false,
+        "required": true,
         "types": [
+          {
+            "type": "field_declaration_list",
+            "named": true
+          },
           {
             "type": "statement_list",
             "named": true
@@ -7409,16 +7407,6 @@
           }
         ]
       }
-    },
-    "children": {
-      "multiple": false,
-      "required": false,
-      "types": [
-        {
-          "type": "field_declaration_list",
-          "named": true
-        }
-      ]
     }
   },
   {


### PR DESCRIPTION
This should align these with their when/case conditional counterparts.