### PR TITLE
use explicit hint tokens for export marker

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -240,7 +240,7 @@ module.exports = grammar({
     $._invalid_layout,
     $._sigil_operator,
     $._prefix_operator,
-    $._symbol_export_marker,
+    $._want_export_marker,
     $._case_of,
   ],
 
@@ -1424,8 +1424,7 @@ module.exports = grammar({
         field("name", choice($._symbol, $.exported_symbol)),
         optional($.pragma_list)
       ),
-    exported_symbol: $ => seq($._symbol, alias($._symbol_export_marker, "*")),
-    _symbol_export_marker: () => "*",
+    exported_symbol: $ => seq($._symbol, optional($._want_export_marker), "*"),
 
     /* Literals */
     _literal: $ =>

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -13124,19 +13124,22 @@
           "name": "_symbol"
         },
         {
-          "type": "ALIAS",
-          "content": {
-            "type": "SYMBOL",
-            "name": "_symbol_export_marker"
-          },
-          "named": false,
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_want_export_marker"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
           "value": "*"
         }
       ]
-    },
-    "_symbol_export_marker": {
-      "type": "STRING",
-      "value": "*"
     },
     "_literal": {
       "type": "CHOICE",
@@ -14498,7 +14501,7 @@
     },
     {
       "type": "SYMBOL",
-      "name": "_symbol_export_marker"
+      "name": "_want_export_marker"
     },
     {
       "type": "SYMBOL",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -85,8 +85,8 @@ _nonnull_(1) _returns_nonnull_ static indent_value* indent_vec_at(
   return &self->data[idx];
 }
 
-_nonnull_(1) static indent_value
-    indent_vec_get(const struct indent_vec* self, int32_t idx)
+_nonnull_(1) static indent_value indent_vec_get(
+    const struct indent_vec* self, int32_t idx)
 {
   return *indent_vec_at((struct indent_vec*)self, idx);
 }
@@ -227,7 +227,7 @@ enum token_type {
   INVALID_LAYOUT,
   SIGIL_OP,
   UNARY_OP,
-  SYM_EXPORT_MARKER,
+  WANT_EXPORT_MARKER,
   OF,
   TOKEN_TYPE_LEN
 };
@@ -249,7 +249,7 @@ const char* const TOKEN_TYPE_STR[TOKEN_TYPE_LEN] = {
     "INVALID_LAYOUT",
     "SIGIL_OP",
     "UNARY_OP",
-    "SYM_EXPORT_MARKER",
+    "WANT_EXPORT_MARKER",
     "OF",
 };
 #endif
@@ -264,8 +264,8 @@ struct valid_tokens {
     .bits = (bits_)         \
   }
 
-_nonnull_(1) _pure_ static struct valid_tokens
-    valid_tokens_from_array(const bool* valid_tokens)
+_nonnull_(1) _pure_ static struct valid_tokens valid_tokens_from_array(
+    const bool* valid_tokens)
 {
   struct valid_tokens result = {0};
   for (unsigned i = TOKEN_TYPE_START; i < TOKEN_TYPE_LEN; i++) {
@@ -917,8 +917,8 @@ const char* const OPERATOR_SCAN_STATE_STR[] = {
     "STAR"};
 #endif
 
-_nonnull_(1) static enum token_type
-    scan_operator(struct context* ctx, bool immediate)
+_nonnull_(1) static enum token_type scan_operator(
+    struct context* ctx, bool immediate)
 {
   if (immediate) {
     return TOKEN_TYPE_LEN;
@@ -1000,7 +1000,7 @@ loop_end:
     }
     break;
   case OS_STAR:
-    if (valid_tokens_test(ctx->valid_tokens, SYM_EXPORT_MARKER)) {
+    if (valid_tokens_test(ctx->valid_tokens, WANT_EXPORT_MARKER)) {
       return TOKEN_TYPE_LEN;
     }
     break;


### PR DESCRIPTION
Since unary operator processing in external scanner conflicts with export marker, the export marker was made into a non-terminal rule that was also an external symbol, where the sole reason for the external symbol was to allow the unary operator handler in the external parser know that the marker `*` is meant to be a marker and not an unary operator.

Recent tree-sitter changes has forbade this particular usage. As such, switch to using a signal token (an optional token that is an external) to let the external scanner know the context it is handling.

Ref: https://github.com/alaviss/tree-sitter-nim/issues/90#issuecomment-2211742258
Ref: https://github.com/tree-sitter/tree-sitter/pull/2577