### PR TITLE
scanner: disable printing for WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,12 +93,34 @@ jobs:
         with:
           command: build
 
+  wasm:
+    needs: [generate]
+    runs-on: ubuntu-latest
+    name: Run WASM test build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download generated parser
+        uses: actions/download-artifact@v4
+        with:
+          name: parser
+          path: src/
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          cache: "npm"
+          node-version: "20"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run test build
+        run: npx tree-sitter build --wasm
+
   success:
     needs:
       - compare-parser
       - generate
       - tests
       - rust
+      - wasm
     if: always()
     runs-on: ubuntu-latest
     name: "All checks passed"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ target/
 *.so
 *.pc
 *.a
+*.wasm

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -47,13 +47,21 @@ static bool debug_mode = false; /* NOLINT(*-global-variables) */
 static const bool debug_mode = false;
 #endif
 
-#define RUNTIME_ASSERT(cond)                                            \
-  if (!(cond)) {                                                        \
-    (void)fprintf(                                                      \
-        stderr, "lex_nim: %s():%d: Assertion `%s' failed.\n", __func__, \
-        __LINE__, #cond);                                               \
-    abort();                                                            \
-  }
+#ifndef __wasm__
+#  define RUNTIME_ASSERT(cond)                                            \
+    if (!(cond)) {                                                        \
+      (void)fprintf(                                                      \
+          stderr, "lex_nim: %s():%d: Assertion `%s' failed.\n", __func__, \
+          __LINE__, #cond);                                               \
+      abort();                                                            \
+    }
+#else
+// WASM doesn't have printing enabled
+#  define RUNTIME_ASSERT(cond) \
+    if (!(cond)) {             \
+      abort();                 \
+    }
+#endif
 
 #define MIN(left, right) ((left) > (right) ? (right) : (left))
 #define MAX(left, right) ((left) < (right) ? (right) : (left))


### PR DESCRIPTION
WASM builds does not expose symbols for printing. As such, settle for simply crashing.

Also add WASM build step to CI to verify that it can be built.

This commit allows the grammar to be used with the Zed editor.