### PR TITLE
Fix character literal not storing its contents

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1460,8 +1460,8 @@ module.exports = grammar({
       seq(
         "'",
         choice(
-          token.immediate(prec(2, /[^\\\n\r']/)),
-          alias($._char_escape_sequence, $.escape_sequence)
+          alias($._char_escape_sequence, $.escape_sequence),
+          alias(token.immediate(prec(2, /[^\\\n\r']/)), $.char_content)
         ),
         token.immediate("'")
       ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -13564,17 +13564,6 @@
           "type": "CHOICE",
           "members": [
             {
-              "type": "IMMEDIATE_TOKEN",
-              "content": {
-                "type": "PREC",
-                "value": 2,
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[^\\\\\\n\\r']"
-                }
-              }
-            },
-            {
               "type": "ALIAS",
               "content": {
                 "type": "SYMBOL",
@@ -13582,6 +13571,22 @@
               },
               "named": true,
               "value": "escape_sequence"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "IMMEDIATE_TOKEN",
+                "content": {
+                  "type": "PREC",
+                  "value": 2,
+                  "content": {
+                    "type": "PATTERN",
+                    "value": "[^\\\\\\n\\r']"
+                  }
+                }
+              },
+              "named": true,
+              "value": "char_content"
             }
           ]
         },

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -852,7 +852,6 @@
   {
     "type": "block_comment",
     "named": true,
-    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -868,7 +867,6 @@
   {
     "type": "block_documentation_comment",
     "named": true,
-    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -2300,7 +2298,6 @@
   {
     "type": "comment",
     "named": true,
-    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -3503,7 +3500,6 @@
   {
     "type": "documentation_comment",
     "named": true,
-    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -852,6 +852,7 @@
   {
     "type": "block_comment",
     "named": true,
+    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -867,6 +868,7 @@
   {
     "type": "block_documentation_comment",
     "named": true,
+    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -1948,8 +1950,12 @@
     "fields": {},
     "children": {
       "multiple": false,
-      "required": false,
+      "required": true,
       "types": [
+        {
+          "type": "char_content",
+          "named": true
+        },
         {
           "type": "escape_sequence",
           "named": true
@@ -2294,6 +2300,7 @@
   {
     "type": "comment",
     "named": true,
+    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -3496,6 +3503,7 @@
   {
     "type": "documentation_comment",
     "named": true,
+    "extra": true,
     "fields": {},
     "children": {
       "multiple": false,
@@ -12110,6 +12118,10 @@
   {
     "type": "cast",
     "named": false
+  },
+  {
+    "type": "char_content",
+    "named": true
   },
   {
     "type": "comment_content",

--- a/test/corpus/deviations.txt
+++ b/test/corpus/deviations.txt
@@ -18,9 +18,10 @@ r"string
     (string_content)
     (block_comment
       (comment_content)))
-  (char_literal
-    (block_comment
-      (comment_content)))
+   (char_literal
+     (char_content)
+     (block_comment
+       (comment_content)))
   (raw_string_literal
     (string_content)
     (block_comment

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -223,10 +223,14 @@ Character literals
 --------------------------------------------------------------------------------
 
 (source_file
-  (char_literal)
-  (char_literal)
-  (char_literal)
-  (char_literal)
+  (char_literal
+    (char_content))
+  (char_literal
+    (char_content))
+  (char_literal
+    (char_content))
+  (char_literal
+    (char_content))
   (char_literal
     (escape_sequence))
   (char_literal


### PR DESCRIPTION
The character literal was only storing its contents in a node when it was an escape sequence. Was writing a formatter with topiary but was running into issues with characters since their contents would get lost e.g.

```nim
discard '?'
discard '\n'
discard "hello"
```

```
[2026-01-01T00:52:38Z ERROR topiary::error] Cause:   × Parsing error between line 0, column 0 and line 0, column 10
       ╭─[standard input:1:1]
     1 │ discard ''
       · ─────┬─────
       ·      ╰── (ERROR) node
     2 │ discard '\n'
     3 │ discard "hello"
       ╰────
```