### PR TITLE
grammar: factor out post expr do block tail into its own rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1006,11 +1006,7 @@ module.exports = grammar({
       ),
     _call_do_argument_list: $ =>
       prec.right(
-        seq(
-          optional($._call_argument_list),
-          $.do_block,
-          optional($._post_expression_block_tail)
-        )
+        seq(optional($._call_argument_list), $._post_expression_do_block)
       ),
     _call_expression: $ =>
       prec(
@@ -1063,11 +1059,13 @@ module.exports = grammar({
       seq(token.immediate("[:"), sep1($._expression, ","), $._bracket_close),
     _post_expression_block: $ =>
       prec.right(
-        seq(
-          choice(seq(":", $.statement_list), $.do_block),
-          optional($._post_expression_block_tail)
+        choice(
+          seq(":", $.statement_list, optional($._post_expression_block_tail)),
+          $._post_expression_do_block
         )
       ),
+    _post_expression_do_block: $ =>
+      prec.right(seq($.do_block, optional($._post_expression_block_tail))),
     _post_expression_block_tail: $ =>
       repeat1(
         seq(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4672,19 +4672,7 @@
           },
           {
             "type": "SYMBOL",
-            "name": "do_block"
-          },
-          {
-            "type": "CHOICE",
-            "members": [
-              {
-                "type": "SYMBOL",
-                "name": "_post_expression_block_tail"
-              },
-              {
-                "type": "BLANK"
-              }
-            ]
+            "name": "_post_expression_do_block"
           }
         ]
       }
@@ -4917,29 +4905,49 @@
       "type": "PREC_RIGHT",
       "value": 0,
       "content": {
-        "type": "SEQ",
+        "type": "CHOICE",
         "members": [
           {
-            "type": "CHOICE",
+            "type": "SEQ",
             "members": [
               {
-                "type": "SEQ",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": ":"
-                  },
-                  {
-                    "type": "SYMBOL",
-                    "name": "statement_list"
-                  }
-                ]
+                "type": "STRING",
+                "value": ":"
               },
               {
                 "type": "SYMBOL",
-                "name": "do_block"
+                "name": "statement_list"
+              },
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "_post_expression_block_tail"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               }
             ]
+          },
+          {
+            "type": "SYMBOL",
+            "name": "_post_expression_do_block"
+          }
+        ]
+      }
+    },
+    "_post_expression_do_block": {
+      "type": "PREC_RIGHT",
+      "value": 0,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "SYMBOL",
+            "name": "do_block"
           },
           {
             "type": "CHOICE",


### PR DESCRIPTION
Previously, the `do` block expression tail was inlined into both post_expression_block_tail and call_do_argument_list. This produced an expensive ambiguity where the parser has to hold a lot of running context before it can decide whether a call_do_argument_list or post_expression_block_tail was found.

This commit introduces a new intermediary `post_expression_do_block`, which allows the parser to reduce the expensive context into a shared symbol before deciding on either of the higher-level ones.

The number of states dropped from 20305 to 13022 (35% reduction), large states dropped from 10594 to 6581 (37% reduction). All of this contributed to a 39% drop in generated parser size.

This optimization was discovered with the help of LLM.

Assisted-by: oh-my-pi:GPT-5.5