### PR TITLE
update python scarffolding and add VS 2022 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: jdx/mise-action@v4
+      - name: Install VS 2022 (Windows)
+        if: runner.os == 'Windows'
+        run: choco install visualstudio2022-workload-vctools -y
       - uses: tree-sitter/parser-test-action@v2
         with:
           abi-version: 14

--- a/bindings/python/tree_sitter_nim/binding.c
+++ b/bindings/python/tree_sitter_nim/binding.c
@@ -9,8 +9,15 @@ typedef struct TSLanguage TSLanguage;
 TSLanguage *tree_sitter_nim(void);
 
 static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_nim());
+    return PyCapsule_New(tree_sitter_nim(), "tree_sitter.Language", NULL);
 }
+
+static struct PyModuleDef_Slot slots[] = {
+#ifdef Py_GIL_DISABLED
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+#endif
+    {0, NULL}
+};
 
 static PyMethodDef methods[] = {
     {"language", _binding_language, METH_NOARGS,
@@ -22,10 +29,11 @@ static struct PyModuleDef module = {
     .m_base = PyModuleDef_HEAD_INIT,
     .m_name = "_binding",
     .m_doc = NULL,
-    .m_size = -1,
-    .m_methods = methods
+    .m_size = 0,
+    .m_methods = methods,
+    .m_slots = slots,
 };
 
 PyMODINIT_FUNC PyInit__binding(void) {
-    return PyModule_Create(&module);
+    return PyModuleDef_Init(&module);
 }


### PR DESCRIPTION
This resolves CI-related issues on Windows and fixes python importing there.